### PR TITLE
feat(busminder): trip persistence, active trip redesign, dark mode fixes

### DIFF
--- a/DriversandMinders/lib/presentation/busminder_active_trip_screen/busminder_active_trip_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_active_trip_screen/busminder_active_trip_screen.dart
@@ -7,6 +7,7 @@ import 'package:sizer/sizer.dart';
 
 import '../../core/app_export.dart';
 import '../../services/api_service.dart';
+import '../../theme/app_theme.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
 import '../busminder_trip_history_screen/busminder_trip_history_screen.dart';
@@ -73,7 +74,9 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
     }
 
     update();
-    _tripTimer = Timer.periodic(const Duration(seconds: 1), (_) => update());
+    _tripTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) update();
+    });
   }
 
   Future<void> _checkActiveTrip() async {
@@ -355,21 +358,26 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
   @override
   Widget build(BuildContext context) {
     if (_isLoading) {
-      return Scaffold(
-          body: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                CircularProgressIndicator(color: Theme.of(context).colorScheme.primary),
-                SizedBox(height: 2.h),
-                Text('Loading trip data...'),
-              ],
-            ),
-          ),
-        );
+      return Theme(
+        data: AppTheme.lightBusminderTheme,
+        child: Scaffold(
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  CircularProgressIndicator(
+                      color: AppTheme.lightBusminderTheme.colorScheme.primary),
+                  SizedBox(height: 2.h),
+                  const Text('Loading trip data...'),
+                ],
+              ),
+            )),
+      );
     }
 
-    return Scaffold(
+    return Theme(
+      data: AppTheme.lightBusminderTheme,
+      child: Scaffold(
         drawer: BusminderDrawerWidget(
             currentRoute: '/busminder-active-trip-screen'),
         appBar: CustomAppBar(
@@ -460,7 +468,8 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
             ],
           ),
         ),
-      );
+      ),
+    );
   }
 
   Widget _buildTripHeader() {

--- a/DriversandMinders/lib/presentation/busminder_active_trip_screen/busminder_active_trip_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_active_trip_screen/busminder_active_trip_screen.dart
@@ -7,6 +7,7 @@ import 'package:sizer/sizer.dart';
 
 import '../../core/app_export.dart';
 import '../../services/api_service.dart';
+import '../../services/theme_service.dart';
 import '../../theme/app_theme.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
@@ -24,6 +25,9 @@ class BusminderActiveTripScreen extends StatefulWidget {
 
 class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
   final ApiService _apiService = ApiService();
+
+  // Busminder theme — set in build() so helper methods use the correct theme
+  ThemeData _busminderTheme = AppTheme.lightBusminderTheme;
 
   // Loading states
   bool _isLoading = true;
@@ -91,7 +95,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
             SnackBar(
               content:
                   Text('No active trip found. Please start a shift first.'),
-              backgroundColor: Theme.of(context).colorScheme.error,
+              backgroundColor: _busminderTheme.colorScheme.error,
               duration: Duration(seconds: 3),
             ),
           );
@@ -269,7 +273,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
               _handleEndShift();
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
+              backgroundColor: _busminderTheme.colorScheme.error,
               foregroundColor: Colors.white,
             ),
             child: Text('End Shift'),
@@ -309,7 +313,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Shift ended successfully!'),
-            backgroundColor: Theme.of(context).colorScheme.secondary,
+            backgroundColor: _busminderTheme.colorScheme.secondary,
           ),
         );
 
@@ -339,7 +343,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Error ending shift. Please try again.'),
-            backgroundColor: Theme.of(context).colorScheme.error,
+            backgroundColor: _busminderTheme.colorScheme.error,
           ),
         );
       }
@@ -357,27 +361,35 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
 
   @override
   Widget build(BuildContext context) {
-    if (_isLoading) {
-      return Theme(
-        data: AppTheme.lightBusminderTheme,
-        child: Scaffold(
-            body: Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CircularProgressIndicator(
-                      color: AppTheme.lightBusminderTheme.colorScheme.primary),
-                  SizedBox(height: 2.h),
-                  const Text('Loading trip data...'),
-                ],
-              ),
-            )),
-      );
-    }
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: ThemeService().themeModeNotifier,
+      builder: (ctx, themeMode, _) {
+        _busminderTheme = themeMode == ThemeMode.dark
+            ? AppTheme.darkBusminderTheme
+            : AppTheme.lightBusminderTheme;
+        final busTheme = _busminderTheme;
 
-    return Theme(
-      data: AppTheme.lightBusminderTheme,
-      child: Scaffold(
+        if (_isLoading) {
+          return Theme(
+            data: busTheme,
+            child: Scaffold(
+                body: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      CircularProgressIndicator(
+                          color: busTheme.colorScheme.primary),
+                      SizedBox(height: 2.h),
+                      const Text('Loading trip data...'),
+                    ],
+                  ),
+                )),
+          );
+        }
+
+        return Theme(
+          data: busTheme,
+          child: Scaffold(
         drawer: BusminderDrawerWidget(
             currentRoute: '/busminder-active-trip-screen'),
         appBar: CustomAppBar(
@@ -410,7 +422,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         ),
         body: RefreshIndicator(
           onRefresh: _handleRefresh,
-          color: Theme.of(context).colorScheme.primary,
+          color: _busminderTheme.colorScheme.primary,
           child: Column(
             children: [
               Expanded(
@@ -435,14 +447,14 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                             child: Column(
                               children: [
                                 Icon(Icons.people_outline,
-                                    size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                                    size: 48, color: _busminderTheme.colorScheme.onSurfaceVariant),
                                 SizedBox(height: 2.h),
                                 Text(
                                   _searchQuery.isNotEmpty
                                       ? 'No students match your search'
                                       : 'No students assigned',
                                   style:
-                                      TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                                      TextStyle(color: _busminderTheme.colorScheme.onSurfaceVariant),
                                 ),
                               ],
                             ),
@@ -468,7 +480,9 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
             ],
           ),
         ),
-      ),
+        ),
+      );
+      },
     );
   }
 
@@ -479,8 +493,8 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
       decoration: BoxDecoration(
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary,
-            Theme.of(context).colorScheme.primary.withOpacity(0.85),
+            _busminderTheme.colorScheme.primary,
+            _busminderTheme.colorScheme.primary.withValues(alpha:0.85),
           ],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
@@ -488,7 +502,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         borderRadius: BorderRadius.circular(16),
         boxShadow: [
           BoxShadow(
-            color: Theme.of(context).colorScheme.primary.withOpacity(0.3),
+            color: _busminderTheme.colorScheme.primary.withValues(alpha:0.3),
             blurRadius: 12,
             offset: Offset(0, 4),
           ),
@@ -499,7 +513,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
           Container(
             padding: EdgeInsets.all(3.w),
             decoration: BoxDecoration(
-              color: Colors.white.withOpacity(0.2),
+              color: Colors.white.withValues(alpha:0.2),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Icon(Icons.directions_bus, color: Colors.white, size: 28),
@@ -545,7 +559,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
           Container(
             padding: EdgeInsets.symmetric(horizontal: 3.w, vertical: 1.h),
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.secondary,
+              color: _busminderTheme.colorScheme.secondary,
               borderRadius: BorderRadius.circular(8),
             ),
             child: Row(
@@ -575,19 +589,19 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         children: [
           Expanded(
               child: _buildStatChip(
-                  'Total', _students.length, Theme.of(context).colorScheme.primary)),
+                  'Total', _students.length, _busminderTheme.colorScheme.primary)),
           SizedBox(width: 2.w),
           Expanded(
               child: _buildStatChip(
-                  'Done', _completedCount, Theme.of(context).colorScheme.secondary)),
+                  'Done', _completedCount, _busminderTheme.colorScheme.secondary)),
           SizedBox(width: 2.w),
           Expanded(
               child: _buildStatChip(
-                  'Absent', _absentCount, Theme.of(context).colorScheme.error)),
+                  'Absent', _absentCount, _busminderTheme.colorScheme.error)),
           SizedBox(width: 2.w),
           Expanded(
               child: _buildStatChip(
-                  'Pending', _pendingCount, Theme.of(context).colorScheme.tertiary)),
+                  'Pending', _pendingCount, _busminderTheme.colorScheme.tertiary)),
         ],
       ),
     );
@@ -597,9 +611,9 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
     return Container(
       padding: EdgeInsets.symmetric(vertical: 1.5.h, horizontal: 2.w),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
+        color: _busminderTheme.cardColor,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withOpacity(0.3)),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
       ),
       child: Column(
         children: [
@@ -616,7 +630,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
             style: TextStyle(
               fontSize: 11,
               fontWeight: FontWeight.w600,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              color: _busminderTheme.colorScheme.onSurfaceVariant,
             ),
           ),
         ],
@@ -631,20 +645,24 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         onChanged: (value) => setState(() => _searchQuery = value),
         decoration: InputDecoration(
           hintText: 'Search students...',
-          prefixIcon: Icon(Icons.search, color: Theme.of(context).colorScheme.onSurfaceVariant),
+          prefixIcon: Icon(Icons.search, color: _busminderTheme.colorScheme.onSurfaceVariant),
           filled: true,
-          fillColor: Colors.white,
+          fillColor: _busminderTheme.cardColor,
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide(color: Colors.grey.shade200),
+            borderSide: BorderSide(
+                color: _busminderTheme.colorScheme.outline
+                    .withValues(alpha: 0.5)),
           ),
           enabledBorder: OutlineInputBorder(
             borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide(color: Colors.grey.shade200),
+            borderSide: BorderSide(
+                color: _busminderTheme.colorScheme.outline
+                    .withValues(alpha: 0.5)),
           ),
           focusedBorder: OutlineInputBorder(
             borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide(color: Theme.of(context).colorScheme.primary),
+            borderSide: BorderSide(color: _busminderTheme.colorScheme.primary),
           ),
           contentPadding:
               EdgeInsets.symmetric(horizontal: 4.w, vertical: 1.5.h),
@@ -664,21 +682,21 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
       margin: EdgeInsets.symmetric(horizontal: 4.w, vertical: 1.h),
       padding: EdgeInsets.all(3.w),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: _busminderTheme.cardColor,
         borderRadius: BorderRadius.circular(14),
         border: Border.all(
           color: isCompleted
-              ? Theme.of(context).colorScheme.secondary.withOpacity(0.3)
+              ? _busminderTheme.colorScheme.secondary.withValues(alpha: 0.35)
               : isAbsent
-                  ? Theme.of(context).colorScheme.error.withOpacity(0.3)
-                  : Colors.grey.shade200,
+                  ? _busminderTheme.colorScheme.error.withValues(alpha: 0.35)
+                  : _busminderTheme.colorScheme.outline.withValues(alpha: 0.5),
           width: 1.5,
         ),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.04),
+            color: Colors.black.withValues(alpha: 0.04),
             blurRadius: 8,
-            offset: Offset(0, 2),
+            offset: const Offset(0, 2),
           ),
         ],
       ),
@@ -689,14 +707,14 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+              color: _busminderTheme.colorScheme.primary.withValues(alpha:0.1),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Center(
               child: Text(
                 _getInitials(student['name'] as String),
                 style: TextStyle(
-                  color: Theme.of(context).colorScheme.primary,
+                  color: _busminderTheme.colorScheme.primary,
                   fontWeight: FontWeight.w700,
                   fontSize: 16,
                 ),
@@ -715,7 +733,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                   style: TextStyle(
                     fontWeight: FontWeight.w600,
                     fontSize: 15,
-                    color: Theme.of(context).colorScheme.onSurface,
+                    color: _busminderTheme.colorScheme.onSurface,
                   ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
@@ -727,13 +745,13 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                       _formatGrade(student['grade']),
                       style: TextStyle(
                         fontSize: 12,
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        color: _busminderTheme.colorScheme.onSurfaceVariant,
                       ),
                     ),
                     if (student['hasSpecialNeeds'] == true) ...[
                       SizedBox(width: 2.w),
                       Icon(Icons.medical_services,
-                          size: 14, color: Theme.of(context).colorScheme.tertiary),
+                          size: 14, color: _busminderTheme.colorScheme.tertiary),
                     ],
                   ],
                 ),
@@ -749,13 +767,13 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                 padding:
                     EdgeInsets.symmetric(horizontal: 2.5.w, vertical: 0.8.h),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.secondary.withOpacity(0.1),
+                  color: _busminderTheme.colorScheme.secondary.withValues(alpha:0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Row(
                   children: [
                     Icon(Icons.check_circle,
-                        size: 16, color: Theme.of(context).colorScheme.secondary),
+                        size: 16, color: _busminderTheme.colorScheme.secondary),
                     SizedBox(width: 1.w),
                     Text(
                       _tripType == 'pickup'
@@ -764,7 +782,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                       style: TextStyle(
                         fontSize: 11,
                         fontWeight: FontWeight.w600,
-                        color: Theme.of(context).colorScheme.secondary,
+                        color: _busminderTheme.colorScheme.secondary,
                       ),
                     ),
                   ],
@@ -778,19 +796,19 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                 padding:
                     EdgeInsets.symmetric(horizontal: 2.5.w, vertical: 0.8.h),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.error.withOpacity(0.1),
+                  color: _busminderTheme.colorScheme.error.withValues(alpha:0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Row(
                   children: [
-                    Icon(Icons.cancel, size: 16, color: Theme.of(context).colorScheme.error),
+                    Icon(Icons.cancel, size: 16, color: _busminderTheme.colorScheme.error),
                     SizedBox(width: 1.w),
                     Text(
                       'Absent • Tap to change',
                       style: TextStyle(
                         fontSize: 11,
                         fontWeight: FontWeight.w600,
-                        color: Theme.of(context).colorScheme.error,
+                        color: _busminderTheme.colorScheme.error,
                       ),
                     ),
                   ],
@@ -803,14 +821,14 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
               children: [
                 _buildActionButton(
                   icon: Icons.check,
-                  color: Theme.of(context).colorScheme.secondary,
+                  color: _busminderTheme.colorScheme.secondary,
                   onTap: () =>
                       _handleStatusChange(student['id'] as int, statusKey),
                 ),
                 SizedBox(width: 2.w),
                 _buildActionButton(
                   icon: Icons.close,
-                  color: Theme.of(context).colorScheme.error,
+                  color: _busminderTheme.colorScheme.error,
                   onTap: () =>
                       _handleStatusChange(student['id'] as int, 'absent'),
                 ),
@@ -832,9 +850,9 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         width: 40,
         height: 40,
         decoration: BoxDecoration(
-          color: color.withOpacity(0.1),
+          color: color.withValues(alpha: 0.12),
           borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: color.withOpacity(0.3)),
+          border: Border.all(color: color.withValues(alpha: 0.35)),
         ),
         child: Center(
           child: Icon(icon, color: color, size: 20),
@@ -848,12 +866,12 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
       child: Container(
         padding: EdgeInsets.all(4.w),
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: _busminderTheme.scaffoldBackgroundColor,
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.08),
+              color: Colors.black.withValues(alpha: 0.08),
               blurRadius: 12,
-              offset: Offset(0, -4),
+              offset: const Offset(0, -4),
             ),
           ],
         ),
@@ -862,7 +880,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
           child: ElevatedButton(
             onPressed: _isEndingShift ? null : _showEndShiftConfirmation,
             style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
+              backgroundColor: _busminderTheme.colorScheme.error,
               foregroundColor: Colors.white,
               padding: EdgeInsets.symmetric(vertical: 2.h),
               shape: RoundedRectangleBorder(

--- a/DriversandMinders/lib/presentation/busminder_active_trip_screen/busminder_active_trip_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_active_trip_screen/busminder_active_trip_screen.dart
@@ -39,12 +39,15 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
   String? _tripType;
   String? _tripStartTime;
   String? _busNumber;
+  String? _driverName;
+  String? _routeName;
   String? _userName;
 
   // Student data
   List<Map<String, dynamic>> _students = [];
   String _searchQuery = '';
   String? _tripDuration;
+  String _clockTime = '';
   Timer? _tripTimer;
 
   @override
@@ -74,6 +77,8 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
 
       setState(() {
         _tripDuration = buffer.toString();
+        _clockTime =
+            '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
       });
     }
 
@@ -130,21 +135,43 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         } catch (_) {}
       }
 
-      // Try to get bus number from API
+      // Pull rich trip metadata (driver, route, bus number) from active trip API
       try {
-        final busesData = await _apiService.getBusMinderBuses();
-        final buses = busesData['buses'] as List<dynamic>?;
-        if (buses != null && _busId != null) {
-          final bus = buses.firstWhere(
-            (b) => (b as Map<String, dynamic>)['id'] == _busId,
-            orElse: () => null,
-          );
-          if (bus != null) {
-            _busNumber =
-                (bus as Map<String, dynamic>)['number_plate'] as String?;
+        final tripData = await _apiService.getBusminderActiveTrip();
+        if (tripData != null) {
+          _busNumber ??= tripData['busNumber'] as String?;
+          _driverName = tripData['driverName'] as String?;
+          _routeName = tripData['route'] as String?;
+          // Use backend startTime if local prefs didn't have it
+          final rawStart = tripData['startTime'] as String?;
+          if (rawStart != null && _tripStartTime == null) {
+            try {
+              final dt = DateTime.parse(rawStart).toLocal();
+              _startTripTimer(dt);
+              _tripStartTime =
+                  '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+            } catch (_) {}
           }
         }
-      } catch (e) {}
+      } catch (_) {}
+
+      // Fallback: bus number from buses list
+      if (_busNumber == null) {
+        try {
+          final busesData = await _apiService.getBusMinderBuses();
+          final buses = busesData['buses'] as List<dynamic>?;
+          if (buses != null && _busId != null) {
+            final bus = buses.firstWhere(
+              (b) => (b as Map<String, dynamic>)['id'] == _busId,
+              orElse: () => null,
+            );
+            if (bus != null) {
+              _busNumber =
+                  (bus as Map<String, dynamic>)['number_plate'] as String?;
+            }
+          }
+        } catch (_) {}
+      }
       _busNumber ??= 'BUS-${_busId?.toString().padLeft(3, '0')}';
 
       // Load students for this bus
@@ -393,9 +420,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
         drawer: BusminderDrawerWidget(
             currentRoute: '/busminder-active-trip-screen'),
         appBar: CustomAppBar(
-          title: 'Active Trip',
-          subtitle:
-              '$_busNumber • ${_tripType == 'pickup' ? 'Pickup' : 'Dropoff'}',
+          title: _tripType == 'pickup' ? 'Pickup Trip' : 'Dropoff Trip',
           leading: Builder(
             builder: (context) => IconButton(
               icon: Icon(Icons.menu, color: Colors.white),
@@ -403,10 +428,6 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
             ),
           ),
           actions: [
-            IconButton(
-              onPressed: _handleRefresh,
-              icon: Icon(Icons.refresh, color: Colors.white),
-            ),
             IconButton(
               icon: Icon(Icons.home_outlined, color: Colors.white),
               onPressed: () {
@@ -416,7 +437,7 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                   (route) => false,
                 );
               },
-              tooltip: 'Back to Start',
+              tooltip: 'Back to Home',
             ),
           ],
         ),
@@ -427,34 +448,31 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
             children: [
               Expanded(
                 child: CustomScrollView(
-                  physics: AlwaysScrollableScrollPhysics(),
+                  physics: const AlwaysScrollableScrollPhysics(),
                   slivers: [
-                    // Trip Header Card
                     SliverToBoxAdapter(child: _buildTripHeader()),
-
-                    // Stats Row
                     SliverToBoxAdapter(child: _buildStatsRow()),
-
-                    // Search Bar
                     SliverToBoxAdapter(child: _buildSearchBar()),
-
-                    // Students List
+                    SliverToBoxAdapter(child: _buildStudentsHeader()),
                     if (_filteredStudents.isEmpty)
                       SliverToBoxAdapter(
                         child: Padding(
-                          padding: EdgeInsets.all(8.w),
+                          padding: EdgeInsets.symmetric(vertical: 6.h),
                           child: Center(
                             child: Column(
                               children: [
-                                Icon(Icons.people_outline,
-                                    size: 48, color: _busminderTheme.colorScheme.onSurfaceVariant),
-                                SizedBox(height: 2.h),
+                                Icon(Icons.people_outline_rounded,
+                                    size: 52,
+                                    color: _busminderTheme.colorScheme.onSurfaceVariant
+                                        .withValues(alpha: 0.4)),
+                                const SizedBox(height: 12),
                                 Text(
                                   _searchQuery.isNotEmpty
                                       ? 'No students match your search'
                                       : 'No students assigned',
-                                  style:
-                                      TextStyle(color: _busminderTheme.colorScheme.onSurfaceVariant),
+                                  style: TextStyle(
+                                      color: _busminderTheme.colorScheme.onSurfaceVariant,
+                                      fontSize: 14),
                                 ),
                               ],
                             ),
@@ -469,13 +487,10 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
                           childCount: _filteredStudents.length,
                         ),
                       ),
-
                     SliverToBoxAdapter(child: SizedBox(height: 2.h)),
                   ],
                 ),
               ),
-
-              // End Shift Button (always visible at bottom)
               _buildEndShiftButton(),
             ],
           ),
@@ -486,93 +501,239 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
     );
   }
 
+  // ── Trip summary header ─────────────────────────────────────────────────────
   Widget _buildTripHeader() {
+    final cs = _busminderTheme.colorScheme;
+    final isPickup = _tripType == 'pickup';
+    final total = _students.length;
+    final done = _completedCount;
+    final progress = total > 0 ? done / total : 0.0;
+
     return Container(
-      margin: EdgeInsets.all(4.w),
+      margin: EdgeInsets.fromLTRB(4.w, 2.h, 4.w, 1.5.h),
       padding: EdgeInsets.all(4.w),
       decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: [
-            _busminderTheme.colorScheme.primary,
-            _busminderTheme.colorScheme.primary.withValues(alpha:0.85),
-          ],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        borderRadius: BorderRadius.circular(16),
+        color: _busminderTheme.cardColor,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: cs.outline.withValues(alpha: 0.15)),
         boxShadow: [
           BoxShadow(
-            color: _busminderTheme.colorScheme.primary.withValues(alpha:0.3),
-            blurRadius: 12,
-            offset: Offset(0, 4),
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 16,
+            offset: const Offset(0, 4),
           ),
         ],
       ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Top row: icon + title + timer pill ──────────────────────────
+          Row(
+            children: [
+              Container(
+                width: 50,
+                height: 50,
+                decoration: BoxDecoration(
+                  color: cs.primary.withValues(alpha: 0.1),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  isPickup
+                      ? Icons.arrow_circle_up_rounded
+                      : Icons.arrow_circle_down_rounded,
+                  color: cs.primary,
+                  size: 26,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  isPickup ? 'Pickup Trip' : 'Dropoff Trip',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    color: cs.onSurface,
+                  ),
+                ),
+              ),
+              // Right side: current time + elapsed duration
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  // Current wall-clock time
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: cs.primary.withValues(alpha: 0.08),
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                          color: cs.primary.withValues(alpha: 0.2)),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 7,
+                          height: 7,
+                          decoration: BoxDecoration(
+                              color: cs.primary, shape: BoxShape.circle),
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          _clockTime.isEmpty ? '--:--' : _clockTime,
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                            color: cs.primary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  // Elapsed duration
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.timer_outlined,
+                          size: 12, color: cs.onSurfaceVariant),
+                      const SizedBox(width: 4),
+                      Text(
+                        _tripDuration ?? '00:00',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: cs.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 14),
+
+          // ── Info grid: 2×2 ──────────────────────────────────────────────
+          Row(
+            children: [
+              Expanded(
+                child: _buildInfoTile(
+                  cs,
+                  Icons.directions_bus_rounded,
+                  'Bus',
+                  _busNumber ?? '—',
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _buildInfoTile(
+                  cs,
+                  Icons.route_rounded,
+                  'Route',
+                  _routeName ?? '—',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: _buildInfoTile(
+                  cs,
+                  Icons.person_rounded,
+                  'Driver',
+                  _driverName ?? '—',
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _buildInfoTile(
+                  cs,
+                  Icons.schedule_rounded,
+                  'Started',
+                  _tripStartTime ?? '--:--',
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 16),
+
+          // ── Progress ────────────────────────────────────────────────────
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '$done of $total ${isPickup ? 'picked up' : 'dropped off'}',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+              Text(
+                '${(progress * 100).round()}%',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: cs.primary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 6,
+              backgroundColor: cs.outline.withValues(alpha: 0.15),
+              valueColor: AlwaysStoppedAnimation<Color>(cs.primary),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoTile(
+      ColorScheme cs, IconData icon, String label, String value) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: cs.primary.withValues(alpha: 0.04),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: cs.outline.withValues(alpha: 0.12)),
+      ),
       child: Row(
         children: [
-          Container(
-            padding: EdgeInsets.all(3.w),
-            decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha:0.2),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Icon(Icons.directions_bus, color: Colors.white, size: 28),
-          ),
-          SizedBox(width: 4.w),
+          Icon(icon, size: 14, color: cs.primary),
+          const SizedBox(width: 6),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  _tripType == 'pickup'
-                      ? 'Morning Pickup'
-                      : 'Afternoon Dropoff',
+                  label,
                   style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 18,
-                    fontWeight: FontWeight.w700,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w500,
+                    color: cs.onSurfaceVariant,
                   ),
                 ),
-                SizedBox(height: 0.5.h),
-                Row(
-                  children: [
-                    Icon(Icons.access_time, color: Colors.white70, size: 14),
-                    SizedBox(width: 1.w),
-                    Expanded(
-                      child: Text(
-                        _tripDuration != null
-                            ? 'Started at ${_tripStartTime ?? 'N/A'} • $_tripDuration'
-                            : 'Started at ${_tripStartTime ?? 'N/A'}',
-                        style: TextStyle(
-                          color: Colors.white70,
-                          fontSize: 13,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 3.w, vertical: 1.h),
-            decoration: BoxDecoration(
-              color: _busminderTheme.colorScheme.secondary,
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Row(
-              children: [
-                Icon(Icons.circle, color: Colors.white, size: 8),
-                SizedBox(width: 1.5.w),
                 Text(
-                  'ACTIVE',
+                  value,
                   style: TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.w700,
-                    fontSize: 11,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: cs.onSurface,
                   ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ],
             ),
@@ -582,54 +743,55 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
     );
   }
 
+  // ── Stats bar ────────────────────────────────────────────────────────────────
   Widget _buildStatsRow() {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 4.w),
-      child: Row(
-        children: [
-          Expanded(
-              child: _buildStatChip(
-                  'Total', _students.length, _busminderTheme.colorScheme.primary)),
-          SizedBox(width: 2.w),
-          Expanded(
-              child: _buildStatChip(
-                  'Done', _completedCount, _busminderTheme.colorScheme.secondary)),
-          SizedBox(width: 2.w),
-          Expanded(
-              child: _buildStatChip(
-                  'Absent', _absentCount, _busminderTheme.colorScheme.error)),
-          SizedBox(width: 2.w),
-          Expanded(
-              child: _buildStatChip(
-                  'Pending', _pendingCount, _busminderTheme.colorScheme.tertiary)),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildStatChip(String label, int count, Color color) {
+    final cs = _busminderTheme.colorScheme;
     return Container(
-      padding: EdgeInsets.symmetric(vertical: 1.5.h, horizontal: 2.w),
+      margin: EdgeInsets.symmetric(horizontal: 4.w),
+      padding: const EdgeInsets.symmetric(vertical: 14),
       decoration: BoxDecoration(
         color: _busminderTheme.cardColor,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withValues(alpha: 0.4)),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: cs.outline.withValues(alpha: 0.15)),
       ),
+      child: Row(
+        children: [
+          _buildStatItem('Total', _students.length, cs.primary),
+          _buildStatDivider(cs),
+          _buildStatItem('Done', _completedCount, const Color(0xFF2E7D32)),
+          _buildStatDivider(cs),
+          _buildStatItem('Absent', _absentCount, cs.error),
+          _buildStatDivider(cs),
+          _buildStatItem('Pending', _pendingCount, const Color(0xFFE65100)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatDivider(ColorScheme cs) => Container(
+        width: 1,
+        height: 36,
+        color: cs.outline.withValues(alpha: 0.2),
+      );
+
+  Widget _buildStatItem(String label, int count, Color color) {
+    return Expanded(
       child: Column(
         children: [
           Text(
             '$count',
             style: TextStyle(
-              fontSize: 20,
+              fontSize: 22,
               fontWeight: FontWeight.w800,
               color: color,
             ),
           ),
+          const SizedBox(height: 2),
           Text(
             label,
             style: TextStyle(
               fontSize: 11,
-              fontWeight: FontWeight.w600,
+              fontWeight: FontWeight.w500,
               color: _busminderTheme.colorScheme.onSurfaceVariant,
             ),
           ),
@@ -638,208 +800,267 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
     );
   }
 
+  // ── Search bar ───────────────────────────────────────────────────────────────
   Widget _buildSearchBar() {
+    final cs = _busminderTheme.colorScheme;
     return Padding(
-      padding: EdgeInsets.all(4.w),
+      padding: EdgeInsets.fromLTRB(4.w, 2.h, 4.w, 0),
       child: TextField(
-        onChanged: (value) => setState(() => _searchQuery = value),
+        onChanged: (v) => setState(() => _searchQuery = v),
+        style: TextStyle(fontSize: 15, color: cs.onSurface),
         decoration: InputDecoration(
           hintText: 'Search students...',
-          prefixIcon: Icon(Icons.search, color: _busminderTheme.colorScheme.onSurfaceVariant),
+          hintStyle: TextStyle(color: cs.onSurfaceVariant, fontSize: 15),
+          prefixIcon: Icon(Icons.search_rounded,
+              color: cs.onSurfaceVariant, size: 22),
           filled: true,
           fillColor: _busminderTheme.cardColor,
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
           border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide(
-                color: _busminderTheme.colorScheme.outline
-                    .withValues(alpha: 0.5)),
+            borderRadius: BorderRadius.circular(14),
+            borderSide:
+                BorderSide(color: cs.outline.withValues(alpha: 0.3)),
           ),
           enabledBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide(
-                color: _busminderTheme.colorScheme.outline
-                    .withValues(alpha: 0.5)),
+            borderRadius: BorderRadius.circular(14),
+            borderSide:
+                BorderSide(color: cs.outline.withValues(alpha: 0.3)),
           ),
           focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide(color: _busminderTheme.colorScheme.primary),
+            borderRadius: BorderRadius.circular(14),
+            borderSide: BorderSide(color: cs.primary, width: 1.5),
           ),
-          contentPadding:
-              EdgeInsets.symmetric(horizontal: 4.w, vertical: 1.5.h),
         ),
       ),
     );
   }
 
+  // ── Students section label ───────────────────────────────────────────────────
+  Widget _buildStudentsHeader() {
+    final cs = _busminderTheme.colorScheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4.w, 2.h, 4.w, 0.5.h),
+      child: Row(
+        children: [
+          Text(
+            'Students',
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: cs.onSurface,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: cs.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(100),
+            ),
+            child: Text(
+              '${_filteredStudents.length}',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: cs.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Student card ─────────────────────────────────────────────────────────────
   Widget _buildStudentCard(Map<String, dynamic> student) {
+    final cs = _busminderTheme.colorScheme;
     final status = student['status'] as String;
     final statusKey = _tripType == 'pickup' ? 'picked_up' : 'dropped_off';
     final isCompleted = status == statusKey;
     final isAbsent = status == 'absent';
-    final isPending = status == 'pending';
+    const doneColor = Color(0xFF2E7D32);
 
     return Container(
-      margin: EdgeInsets.symmetric(horizontal: 4.w, vertical: 1.h),
-      padding: EdgeInsets.all(3.w),
+      margin: EdgeInsets.symmetric(horizontal: 4.w, vertical: 0.5.h),
       decoration: BoxDecoration(
         color: _busminderTheme.cardColor,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-          color: isCompleted
-              ? _busminderTheme.colorScheme.secondary.withValues(alpha: 0.35)
-              : isAbsent
-                  ? _busminderTheme.colorScheme.error.withValues(alpha: 0.35)
-                  : _busminderTheme.colorScheme.outline.withValues(alpha: 0.5),
-          width: 1.5,
-        ),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: cs.outline.withValues(alpha: 0.12)),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
+            color: Colors.black.withValues(alpha: 0.03),
             blurRadius: 8,
             offset: const Offset(0, 2),
           ),
         ],
       ),
-      child: Row(
-        children: [
-          // Avatar
-          Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              color: _busminderTheme.colorScheme.primary.withValues(alpha:0.1),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Center(
-              child: Text(
-                _getInitials(student['name'] as String),
-                style: TextStyle(
-                  color: _busminderTheme.colorScheme.primary,
-                  fontWeight: FontWeight.w700,
-                  fontSize: 16,
-                ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Left status accent bar
+              Container(
+                width: 4,
+                color: isCompleted
+                    ? doneColor
+                    : isAbsent
+                        ? cs.error
+                        : cs.outline.withValues(alpha: 0.25),
               ),
-            ),
-          ),
-          SizedBox(width: 3.w),
-
-          // Name and grade
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  student['name'] as String,
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
-                    fontSize: 15,
-                    color: _busminderTheme.colorScheme.onSurface,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                SizedBox(height: 0.3.h),
-                Row(
-                  children: [
-                    Text(
-                      _formatGrade(student['grade']),
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: _busminderTheme.colorScheme.onSurfaceVariant,
+              Expanded(
+                child: Padding(
+                  padding: EdgeInsets.symmetric(
+                      horizontal: 3.5.w, vertical: 1.4.h),
+                  child: Row(
+                    children: [
+                      // Circle avatar
+                      Container(
+                        width: 46,
+                        height: 46,
+                        decoration: BoxDecoration(
+                          color: cs.primary.withValues(alpha: 0.1),
+                          shape: BoxShape.circle,
+                        ),
+                        child: Center(
+                          child: Text(
+                            _getInitials(student['name'] as String),
+                            style: TextStyle(
+                              color: cs.primary,
+                              fontWeight: FontWeight.w700,
+                              fontSize: 15,
+                            ),
+                          ),
+                        ),
                       ),
-                    ),
-                    if (student['hasSpecialNeeds'] == true) ...[
-                      SizedBox(width: 2.w),
-                      Icon(Icons.medical_services,
-                          size: 14, color: _busminderTheme.colorScheme.tertiary),
+                      const SizedBox(width: 12),
+                      // Name + grade
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              student['name'] as String,
+                              style: TextStyle(
+                                fontWeight: FontWeight.w600,
+                                fontSize: 15,
+                                color: cs.onSurface,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            const SizedBox(height: 3),
+                            Row(
+                              children: [
+                                Text(
+                                  _formatGrade(student['grade']),
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                                ),
+                                if (student['hasSpecialNeeds'] == true) ...[
+                                  const SizedBox(width: 6),
+                                  Icon(
+                                      Icons.medical_services_outlined,
+                                      size: 13,
+                                      color: cs.tertiary),
+                                ],
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      // Right: pill or action buttons
+                      if (isCompleted)
+                        _buildStatusPill(
+                          label: _tripType == 'pickup'
+                              ? 'Picked Up'
+                              : 'Dropped',
+                          color: doneColor,
+                          icon: Icons.check_circle_outline_rounded,
+                          onTap: () => _handleStatusChange(
+                              student['id'] as int, 'pending'),
+                        )
+                      else if (isAbsent)
+                        _buildStatusPill(
+                          label: 'Absent',
+                          color: cs.error,
+                          icon: Icons.cancel_outlined,
+                          onTap: () => _handleStatusChange(
+                              student['id'] as int, 'pending'),
+                        )
+                      else
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            _buildRoundButton(
+                              icon: Icons.check_rounded,
+                              color: doneColor,
+                              onTap: () => _handleStatusChange(
+                                  student['id'] as int, statusKey),
+                            ),
+                            const SizedBox(width: 8),
+                            _buildRoundButton(
+                              icon: Icons.close_rounded,
+                              color: cs.error,
+                              onTap: () => _handleStatusChange(
+                                  student['id'] as int, 'absent'),
+                            ),
+                          ],
+                        ),
                     ],
-                  ],
+                  ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-
-          // Status indicator
-          if (isCompleted)
-            GestureDetector(
-              onTap: () => _handleStatusChange(student['id'] as int, 'pending'),
-              child: Container(
-                padding:
-                    EdgeInsets.symmetric(horizontal: 2.5.w, vertical: 0.8.h),
-                decoration: BoxDecoration(
-                  color: _busminderTheme.colorScheme.secondary.withValues(alpha:0.1),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Row(
-                  children: [
-                    Icon(Icons.check_circle,
-                        size: 16, color: _busminderTheme.colorScheme.secondary),
-                    SizedBox(width: 1.w),
-                    Text(
-                      _tripType == 'pickup'
-                          ? 'Picked Up • Tap to change'
-                          : 'Dropped Off • Tap to change',
-                      style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
-                        color: _busminderTheme.colorScheme.secondary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            )
-          else if (isAbsent)
-            GestureDetector(
-              onTap: () => _handleStatusChange(student['id'] as int, 'pending'),
-              child: Container(
-                padding:
-                    EdgeInsets.symmetric(horizontal: 2.5.w, vertical: 0.8.h),
-                decoration: BoxDecoration(
-                  color: _busminderTheme.colorScheme.error.withValues(alpha:0.1),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Row(
-                  children: [
-                    Icon(Icons.cancel, size: 16, color: _busminderTheme.colorScheme.error),
-                    SizedBox(width: 1.w),
-                    Text(
-                      'Absent • Tap to change',
-                      style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w600,
-                        color: _busminderTheme.colorScheme.error,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            )
-          else
-            // Action buttons for pending
-            Row(
-              children: [
-                _buildActionButton(
-                  icon: Icons.check,
-                  color: _busminderTheme.colorScheme.secondary,
-                  onTap: () =>
-                      _handleStatusChange(student['id'] as int, statusKey),
-                ),
-                SizedBox(width: 2.w),
-                _buildActionButton(
-                  icon: Icons.close,
-                  color: _busminderTheme.colorScheme.error,
-                  onTap: () =>
-                      _handleStatusChange(student['id'] as int, 'absent'),
-                ),
-              ],
-            ),
-        ],
+        ),
       ),
     );
   }
 
-  Widget _buildActionButton({
+  Widget _buildStatusPill({
+    required String label,
+    required Color color,
+    required IconData icon,
+    required VoidCallback onTap,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding:
+            const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(100),
+          border: Border.all(color: color.withValues(alpha: 0.25)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 14, color: color),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRoundButton({
     required IconData icon,
     required Color color,
     required VoidCallback onTap,
@@ -847,70 +1068,84 @@ class _BusminderActiveTripScreenState extends State<BusminderActiveTripScreen> {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: 40,
-        height: 40,
+        width: 38,
+        height: 38,
         decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.12),
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: color.withValues(alpha: 0.35)),
+          color: color.withValues(alpha: 0.1),
+          shape: BoxShape.circle,
+          border: Border.all(color: color.withValues(alpha: 0.3)),
         ),
-        child: Center(
-          child: Icon(icon, color: color, size: 20),
-        ),
+        child: Icon(icon, color: color, size: 20),
       ),
     );
   }
 
+  // ── End shift button ─────────────────────────────────────────────────────────
   Widget _buildEndShiftButton() {
+    final cs = _busminderTheme.colorScheme;
     return SafeArea(
       child: Container(
-        padding: EdgeInsets.all(4.w),
+        padding: EdgeInsets.fromLTRB(4.w, 1.5.h, 4.w, 1.h),
         decoration: BoxDecoration(
           color: _busminderTheme.scaffoldBackgroundColor,
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.08),
-              blurRadius: 12,
+              color: Colors.black.withValues(alpha: 0.06),
+              blurRadius: 16,
               offset: const Offset(0, -4),
             ),
           ],
         ),
-        child: SizedBox(
-          width: double.infinity,
-          child: ElevatedButton(
-            onPressed: _isEndingShift ? null : _showEndShiftConfirmation,
-            style: ElevatedButton.styleFrom(
-              backgroundColor: _busminderTheme.colorScheme.error,
-              foregroundColor: Colors.white,
-              padding: EdgeInsets.symmetric(vertical: 2.h),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(14),
+        child: GestureDetector(
+          onTap: _isEndingShift ? null : _showEndShiftConfirmation,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            height: 56,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [cs.error, cs.error.withValues(alpha: 0.85)],
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
               ),
-              elevation: 0,
-            ),
-            child: _isEndingShift
-                ? SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: CircularProgressIndicator(
-                      color: Colors.white,
-                      strokeWidth: 2,
-                    ),
-                  )
-                : Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.stop_circle, size: 22),
-                      SizedBox(width: 2.w),
-                      Text(
-                        'End Shift',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w700,
-                          fontSize: 16,
-                        ),
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: _isEndingShift
+                  ? []
+                  : [
+                      BoxShadow(
+                        color: cs.error.withValues(alpha: 0.35),
+                        blurRadius: 12,
+                        offset: const Offset(0, 4),
                       ),
                     ],
-                  ),
+            ),
+            child: Center(
+              child: _isEndingShift
+                  ? const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2.5,
+                      ),
+                    )
+                  : const Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.stop_circle_outlined,
+                            color: Colors.white, size: 22),
+                        SizedBox(width: 10),
+                        Text(
+                          'End Shift',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w700,
+                            fontSize: 17,
+                            letterSpacing: 0.3,
+                          ),
+                        ),
+                      ],
+                    ),
+            ),
           ),
         ),
       ),

--- a/DriversandMinders/lib/presentation/busminder_profile_screen/busminder_profile_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_profile_screen/busminder_profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../services/theme_service.dart';
 import '../../theme/app_theme.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
@@ -57,13 +58,24 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = AppTheme.lightBusminderTheme;
-    final colorScheme = theme.colorScheme;
-    final isDark = false;
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: ThemeService().themeModeNotifier,
+      builder: (ctx, themeMode, _) {
+        final theme = themeMode == ThemeMode.dark
+            ? AppTheme.darkBusminderTheme
+            : AppTheme.lightBusminderTheme;
+        final colorScheme = theme.colorScheme;
+        final isDark = themeMode == ThemeMode.dark;
+        return Theme(
+          data: theme,
+          child: _buildScaffold(colorScheme, isDark, theme),
+        );
+      },
+    );
+  }
 
-    return Theme(
-      data: theme,
-      child: Scaffold(
+  Widget _buildScaffold(ColorScheme colorScheme, bool isDark, ThemeData theme) {
+    return Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
       appBar: CustomAppBar(
         title: 'My Profile',
@@ -236,7 +248,6 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
                 ),
               ),
             ),
-      ),
     );
   }
 

--- a/DriversandMinders/lib/presentation/busminder_profile_screen/busminder_profile_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_profile_screen/busminder_profile_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:sizer/sizer.dart';
 
-import '../../core/app_export.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
 
@@ -25,23 +23,16 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
 
   Future<void> _loadProfile() async {
     setState(() => _isLoading = true);
-
     try {
       final prefs = await SharedPreferences.getInstance();
-      final userId = prefs.getInt('user_id');
-      final userName = prefs.getString('user_name') ?? 'Bus Minder';
-      final userPhone = prefs.getString('user_phone') ?? 'N/A';
-
       setState(() {
         _profileData = {
-          'id': userId,
-          'name': userName,
-          'phone': userPhone,
+          'id': prefs.getInt('user_id'),
+          'name': prefs.getString('user_name') ?? 'Bus Minder',
+          'phone': prefs.getString('user_phone') ?? 'N/A',
           'role': 'Bus Minder',
           'email': prefs.getString('user_email') ?? 'N/A',
           'joined_date': 'January 2026',
-          'trips_completed': 0,
-          'attendance_recorded': 0,
         };
         _isLoading = false;
       });
@@ -50,39 +41,230 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
     }
   }
 
-  Widget _buildInfoCard({
-    required IconData icon,
-    required String label,
-    required String value,
-    Color? iconColor,
-  }) {
-    return Container(
-      padding: EdgeInsets.all(4.w),
-      margin: EdgeInsets.only(bottom: 2.h),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline,
-          width: 1,
+  String get _initials {
+    final name = (_profileData['name'] ?? '').toString().trim();
+    if (name.isEmpty) return 'B';
+    final parts = name.split(' ');
+    if (parts.length >= 2) return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+    return name[0].toUpperCase();
+  }
+
+  String get _employeeId {
+    final id = _profileData['id'];
+    return 'BM-${id?.toString().padLeft(4, '0') ?? '0000'}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
+      appBar: CustomAppBar(
+        title: 'My Profile',
+        automaticallyImplyLeading: false,
+        leading: Builder(
+          builder: (context) => IconButton(
+            icon: const Icon(Icons.menu, color: Colors.white),
+            onPressed: () => Scaffold.of(context).openDrawer(),
+          ),
         ),
+        backgroundColor: colorScheme.primary,
       ),
+      drawer: const BusminderDrawerWidget(currentRoute: '/busminder-profile'),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _loadProfile,
+              child: SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Divider(
+                      height: 1,
+                      color: colorScheme.outline.withValues(alpha: 0.3),
+                    ),
+
+                    // ── Profile header ──────────────────────────────────
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 24, 20, 28),
+                      child: Row(
+                        children: [
+                          Container(
+                            width: 72,
+                            height: 72,
+                            decoration: BoxDecoration(
+                              color: isDark
+                                  ? colorScheme.primary.withValues(alpha: 0.15)
+                                  : colorScheme.primaryContainer,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Center(
+                              child: Text(
+                                _initials,
+                                style: TextStyle(
+                                  fontSize: 26,
+                                  fontWeight: FontWeight.w700,
+                                  color: colorScheme.primary,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  _profileData['name'] ?? 'Bus Minder',
+                                  style: TextStyle(
+                                    fontSize: 20,
+                                    fontWeight: FontWeight.w700,
+                                    color: colorScheme.onSurface,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                const SizedBox(height: 5),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 10, vertical: 3),
+                                  decoration: BoxDecoration(
+                                    color: colorScheme.primary
+                                        .withValues(alpha: 0.12),
+                                    borderRadius: BorderRadius.circular(20),
+                                  ),
+                                  child: Text(
+                                    _profileData['role'] ?? 'Bus Minder',
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w600,
+                                      color: colorScheme.primary,
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  _profileData['email'] ?? '',
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    // ── Contact Information ─────────────────────────────
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
+                      child: Text(
+                        'Contact Information',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                          color: colorScheme.onSurface,
+                        ),
+                      ),
+                    ),
+
+                    Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 20),
+                      decoration: BoxDecoration(
+                        color: theme.cardColor,
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(color: colorScheme.outline),
+                      ),
+                      child: Column(
+                        children: [
+                          _InfoRow(
+                            icon: Icons.phone_rounded,
+                            label: 'Phone Number',
+                            value: _profileData['phone'] ?? 'N/A',
+                            colorScheme: colorScheme,
+                          ),
+                          _divider(colorScheme),
+                          _InfoRow(
+                            icon: Icons.email_rounded,
+                            label: 'Email',
+                            value: _profileData['email'] ?? 'N/A',
+                            colorScheme: colorScheme,
+                          ),
+                          _divider(colorScheme),
+                          _InfoRow(
+                            icon: Icons.badge_rounded,
+                            label: 'Employee ID',
+                            value: _employeeId,
+                            colorScheme: colorScheme,
+                          ),
+                          _divider(colorScheme),
+                          _InfoRow(
+                            icon: Icons.calendar_today_rounded,
+                            label: 'Joined Date',
+                            value: _profileData['joined_date'] ?? 'N/A',
+                            colorScheme: colorScheme,
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    const SizedBox(height: 48),
+
+                    Center(
+                      child: Text(
+                        '© 2026 ApoBasi – Powered by SoG',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+
+                    const SizedBox(height: 32),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+
+  Widget _divider(ColorScheme colorScheme) => Divider(
+        height: 1,
+        indent: 16,
+        endIndent: 16,
+        color: colorScheme.outline.withValues(alpha: 0.5),
+      );
+}
+
+class _InfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final ColorScheme colorScheme;
+
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.colorScheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
       child: Row(
         children: [
-          Container(
-            padding: EdgeInsets.all(3.w),
-            decoration: BoxDecoration(
-              color: (iconColor ?? Theme.of(context).colorScheme.primary)
-                  .withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Icon(
-              icon,
-              color: iconColor ?? Theme.of(context).colorScheme.primary,
-              size: 24,
-            ),
-          ),
-          SizedBox(width: 4.w),
+          Icon(icon, size: 20, color: colorScheme.onSurfaceVariant),
+          const SizedBox(width: 14),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -90,18 +272,18 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
                 Text(
                   label,
                   style: TextStyle(
-                    fontSize: 13,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w500,
+                    fontSize: 12,
+                    color: colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w400,
                   ),
                 ),
-                SizedBox(height: 0.5.h),
+                const SizedBox(height: 2),
                 Text(
                   value,
                   style: TextStyle(
-                    fontSize: 16,
-                    color: Theme.of(context).colorScheme.onSurface,
+                    fontSize: 15,
                     fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurface,
                   ),
                 ),
               ],
@@ -109,225 +291,6 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildStatCard({
-    required IconData icon,
-    required String label,
-    required String value,
-    required Color color,
-  }) {
-    return Expanded(
-      child: Container(
-        padding: EdgeInsets.all(4.w),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              color.withValues(alpha: 0.1),
-              color.withValues(alpha: 0.05),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: color.withValues(alpha: 0.2),
-            width: 1,
-          ),
-        ),
-        child: Column(
-          children: [
-            Icon(icon, color: color, size: 32),
-            SizedBox(height: 1.h),
-            Text(
-              value,
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                color: color,
-              ),
-            ),
-            SizedBox(height: 0.5.h),
-            Text(
-              label,
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 12,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: CustomAppBar(
-        title: 'My Profile',
-        automaticallyImplyLeading: false,
-        leading: Builder(
-          builder: (context) => IconButton(
-            icon: Icon(Icons.menu, color: Colors.white),
-            onPressed: () => Scaffold.of(context).openDrawer(),
-          ),
-        ),
-        backgroundColor: Theme.of(context).colorScheme.primary,
-      ),
-      drawer: const BusminderDrawerWidget(currentRoute: '/busminder-profile'),
-      body: _isLoading
-          ? Center(child: CircularProgressIndicator())
-          : RefreshIndicator(
-              onRefresh: _loadProfile,
-              child: SingleChildScrollView(
-                physics: AlwaysScrollableScrollPhysics(),
-                child: Padding(
-                  padding: EdgeInsets.all(4.w),
-                  child: Column(
-                    children: [
-                      // Profile Avatar Section
-                      Container(
-                        padding: EdgeInsets.all(6.w),
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            colors: [
-                              Theme.of(context).colorScheme.primary,
-                              Theme.of(context).colorScheme.primaryContainer,
-                            ],
-                            begin: Alignment.topLeft,
-                            end: Alignment.bottomRight,
-                          ),
-                          borderRadius: BorderRadius.circular(20),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Theme.of(context).colorScheme.primary
-                                  .withValues(alpha: 0.3),
-                              blurRadius: 15,
-                              offset: Offset(0, 5),
-                            ),
-                          ],
-                        ),
-                        child: Column(
-                          children: [
-                            CircleAvatar(
-                              radius: 50,
-                              backgroundColor: Colors.white,
-                              child: Icon(
-                                Icons.person,
-                                size: 50,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                            ),
-                            SizedBox(height: 2.h),
-                            Text(
-                              _profileData['name'] ?? 'Bus Minder',
-                              style: TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.bold,
-                                color: Colors.white,
-                              ),
-                            ),
-                            SizedBox(height: 0.5.h),
-                            Container(
-                              padding: EdgeInsets.symmetric(
-                                horizontal: 3.w,
-                                vertical: 1.h,
-                              ),
-                              decoration: BoxDecoration(
-                                color: Colors.white.withValues(alpha: 0.2),
-                                borderRadius: BorderRadius.circular(20),
-                              ),
-                              child: Text(
-                                _profileData['role'] ?? 'Bus Minder',
-                                style: TextStyle(
-                                  fontSize: 14,
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-
-                      SizedBox(height: 3.h),
-
-                      // Statistics Section
-                      Row(
-                        children: [
-                          _buildStatCard(
-                            icon: Icons.route,
-                            label: 'Trips\nCompleted',
-                            value:
-                                _profileData['trips_completed']?.toString() ??
-                                    '0',
-                            color: Theme.of(context).colorScheme.secondary,
-                          ),
-                          SizedBox(width: 3.w),
-                          _buildStatCard(
-                            icon: Icons.how_to_reg,
-                            label: 'Attendance\nRecorded',
-                            value: _profileData['attendance_recorded']
-                                    ?.toString() ??
-                                '0',
-                            color: Theme.of(context).colorScheme.tertiary,
-                          ),
-                        ],
-                      ),
-
-                      SizedBox(height: 3.h),
-
-                      // Contact Information
-                      _buildInfoCard(
-                        icon: Icons.phone,
-                        label: 'Phone Number',
-                        value: _profileData['phone'] ?? 'N/A',
-                        iconColor: Theme.of(context).colorScheme.primary,
-                      ),
-
-                      _buildInfoCard(
-                        icon: Icons.email,
-                        label: 'Email',
-                        value: _profileData['email'] ?? 'N/A',
-                        iconColor: Theme.of(context).colorScheme.primary,
-                      ),
-
-                      _buildInfoCard(
-                        icon: Icons.badge,
-                        label: 'Employee ID',
-                        value:
-                            'BM-${_profileData['id']?.toString().padLeft(4, '0') ?? '0000'}',
-                        iconColor: Theme.of(context).colorScheme.primary,
-                      ),
-
-                      _buildInfoCard(
-                        icon: Icons.calendar_today,
-                        label: 'Joined Date',
-                        value: _profileData['joined_date'] ?? 'N/A',
-                        iconColor: Theme.of(context).colorScheme.primary,
-                      ),
-
-                      SizedBox(height: 2.h),
-
-                      // Footer
-                      Text(
-                        '© 2026 ApoBasi - Powered by SoG',
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                      SizedBox(height: 2.h),
-                    ],
-                  ),
-                ),
-              ),
-            ),
     );
   }
 }

--- a/DriversandMinders/lib/presentation/busminder_profile_screen/busminder_profile_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_profile_screen/busminder_profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../theme/app_theme.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
 
@@ -56,11 +57,13 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final theme = AppTheme.lightBusminderTheme;
     final colorScheme = theme.colorScheme;
-    final isDark = theme.brightness == Brightness.dark;
+    final isDark = false;
 
-    return Scaffold(
+    return Theme(
+      data: theme,
+      child: Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
       appBar: CustomAppBar(
         title: 'My Profile',
@@ -233,6 +236,7 @@ class _BusminderProfileScreenState extends State<BusminderProfileScreen> {
                 ),
               ),
             ),
+      ),
     );
   }
 

--- a/DriversandMinders/lib/presentation/busminder_settings_screen/busminder_settings_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_settings_screen/busminder_settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../services/theme_service.dart';
 import '../../theme/app_theme.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
@@ -31,7 +32,8 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
       _notificationsEnabled = prefs.getBool('notifications_enabled') ?? true;
       _soundEnabled = prefs.getBool('sound_enabled') ?? true;
       _vibrationEnabled = prefs.getBool('vibration_enabled') ?? true;
-      _darkMode = prefs.getBool('dark_mode') ?? false;
+      // Sync with ThemeService as source of truth
+      _darkMode = ThemeService().themeMode == ThemeMode.dark;
     });
   }
 
@@ -72,12 +74,24 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = AppTheme.lightBusminderTheme;
-    final colorScheme = theme.colorScheme;
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: ThemeService().themeModeNotifier,
+      builder: (ctx, themeMode, _) {
+        final theme = themeMode == ThemeMode.dark
+            ? AppTheme.darkBusminderTheme
+            : AppTheme.lightBusminderTheme;
+        final colorScheme = theme.colorScheme;
+        return Theme(
+          data: theme,
+          child: _buildContent(ctx, theme, colorScheme),
+        );
+      },
+    );
+  }
 
-    return Theme(
-      data: theme,
-      child: Scaffold(
+  Widget _buildContent(
+      BuildContext context, ThemeData theme, ColorScheme colorScheme) {
+    return Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
       appBar: CustomAppBar(
         title: 'Settings',
@@ -156,6 +170,8 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
                   onChanged: (v) {
                     setState(() => _darkMode = v);
                     _saveSetting('dark_mode', v);
+                    ThemeService().setThemeMode(
+                        v ? ThemeMode.dark : ThemeMode.light);
                   },
                   colorScheme: colorScheme,
                 ),
@@ -203,7 +219,6 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
             const SizedBox(height: 32),
           ],
         ),
-      ),
       ),
     );
   }

--- a/DriversandMinders/lib/presentation/busminder_settings_screen/busminder_settings_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_settings_screen/busminder_settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../theme/app_theme.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
 
@@ -71,10 +72,12 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final theme = AppTheme.lightBusminderTheme;
     final colorScheme = theme.colorScheme;
 
-    return Scaffold(
+    return Theme(
+      data: theme,
+      child: Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
       appBar: CustomAppBar(
         title: 'Settings',
@@ -200,6 +203,7 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
             const SizedBox(height: 32),
           ],
         ),
+      ),
       ),
     );
   }

--- a/DriversandMinders/lib/presentation/busminder_settings_screen/busminder_settings_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_settings_screen/busminder_settings_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:sizer/sizer.dart';
 
-import '../../core/app_export.dart';
 import '../../widgets/custom_app_bar.dart';
 import '../../widgets/busminder_drawer_widget.dart';
 
@@ -18,7 +16,7 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
   bool _notificationsEnabled = true;
   bool _soundEnabled = true;
   bool _vibrationEnabled = true;
-  String _language = 'English';
+  bool _darkMode = false;
 
   @override
   void initState() {
@@ -32,284 +30,322 @@ class _BusminderSettingsScreenState extends State<BusminderSettingsScreen> {
       _notificationsEnabled = prefs.getBool('notifications_enabled') ?? true;
       _soundEnabled = prefs.getBool('sound_enabled') ?? true;
       _vibrationEnabled = prefs.getBool('vibration_enabled') ?? true;
-      _language = prefs.getString('language') ?? 'English';
+      _darkMode = prefs.getBool('dark_mode') ?? false;
     });
   }
 
-  Future<void> _saveSetting(String key, dynamic value) async {
+  Future<void> _saveSetting(String key, bool value) async {
     final prefs = await SharedPreferences.getInstance();
-    if (value is bool) {
-      await prefs.setBool(key, value);
-    } else if (value is String) {
-      await prefs.setString(key, value);
-    }
+    await prefs.setBool(key, value);
   }
 
-  Widget _buildSettingsSection({
-    required String title,
-    required List<Widget> children,
-  }) {
-    return Container(
-      margin: EdgeInsets.only(bottom: 3.h),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline,
-          width: 1,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: EdgeInsets.all(4.w),
-            child: Text(
-              title,
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-                color: Theme.of(context).colorScheme.primary,
-              ),
+  void _showAboutDialog() {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        title: const Text('About ApoBasi'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Version: 1.0.0+3'),
+            SizedBox(height: 8),
+            Text('© 2026 ApoBasi – Powered by SoG'),
+            SizedBox(height: 8),
+            Text(
+              'School bus tracking and attendance management for African schools.',
+              style: TextStyle(fontSize: 13),
             ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Close'),
           ),
-          Divider(height: 1, color: Theme.of(context).colorScheme.outline),
-          ...children,
         ],
       ),
     );
   }
 
-  Widget _buildSwitchTile({
-    required IconData icon,
-    required String title,
-    required String subtitle,
-    required bool value,
-    required Function(bool) onChanged,
-  }) {
-    return ListTile(
-      leading: Container(
-        padding: EdgeInsets.all(2.w),
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Icon(icon, color: Theme.of(context).colorScheme.primary, size: 22),
-      ),
-      title: Text(
-        title,
-        style: TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
-      ),
-      subtitle: Text(
-        subtitle,
-        style: TextStyle(
-          fontSize: 13,
-          color: Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
-      ),
-      trailing: Switch(
-        value: value,
-        onChanged: onChanged,
-        activeColor: Theme.of(context).colorScheme.primary,
-      ),
-    );
-  }
-
-  Widget _buildActionTile({
-    required IconData icon,
-    required String title,
-    required String subtitle,
-    required VoidCallback onTap,
-    Color? iconColor,
-  }) {
-    return ListTile(
-      leading: Container(
-        padding: EdgeInsets.all(2.w),
-        decoration: BoxDecoration(
-          color:
-              (iconColor ?? Theme.of(context).colorScheme.primary).withValues(alpha: 0.1),
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Icon(
-          icon,
-          color: iconColor ?? Theme.of(context).colorScheme.primary,
-          size: 22,
-        ),
-      ),
-      title: Text(
-        title,
-        style: TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
-      ),
-      subtitle: Text(
-        subtitle,
-        style: TextStyle(
-          fontSize: 13,
-          color: Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
-      ),
-      trailing: Icon(
-        Icons.chevron_right,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
-      onTap: onTap,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return Scaffold(
+      backgroundColor: theme.scaffoldBackgroundColor,
       appBar: CustomAppBar(
         title: 'Settings',
         automaticallyImplyLeading: false,
         leading: Builder(
           builder: (context) => IconButton(
-            icon: Icon(Icons.menu, color: Colors.white),
+            icon: const Icon(Icons.menu, color: Colors.white),
             onPressed: () => Scaffold.of(context).openDrawer(),
           ),
         ),
-        backgroundColor: Theme.of(context).colorScheme.primary,
+        backgroundColor: colorScheme.primary,
       ),
       drawer: const BusminderDrawerWidget(currentRoute: '/busminder-settings'),
       body: SingleChildScrollView(
-        padding: EdgeInsets.all(4.w),
+        physics: const AlwaysScrollableScrollPhysics(),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Notifications Section
-            _buildSettingsSection(
-              title: 'Notifications',
+            Divider(height: 1, color: colorScheme.outline.withValues(alpha: 0.3)),
+
+            // ── Notifications ─────────────────────────────────────────
+            _sectionHeader('Notifications', colorScheme),
+
+            _GroupedCard(
+              theme: theme,
+              colorScheme: colorScheme,
               children: [
-                _buildSwitchTile(
-                  icon: Icons.notifications,
-                  title: 'Push Notifications',
-                  subtitle: 'Receive alerts for trip updates',
+                _SwitchRow(
+                  icon: Icons.notifications_rounded,
+                  label: 'Push Notifications',
                   value: _notificationsEnabled,
-                  onChanged: (value) {
-                    setState(() => _notificationsEnabled = value);
-                    _saveSetting('notifications_enabled', value);
+                  onChanged: (v) {
+                    setState(() => _notificationsEnabled = v);
+                    _saveSetting('notifications_enabled', v);
                   },
+                  colorScheme: colorScheme,
                 ),
-                Divider(height: 1, color: Theme.of(context).colorScheme.outline),
-                _buildSwitchTile(
-                  icon: Icons.volume_up,
-                  title: 'Sound',
-                  subtitle: 'Play sound for notifications',
+                _divider(colorScheme),
+                _SwitchRow(
+                  icon: Icons.volume_up_rounded,
+                  label: 'Sound',
                   value: _soundEnabled,
-                  onChanged: (value) {
-                    setState(() => _soundEnabled = value);
-                    _saveSetting('sound_enabled', value);
+                  onChanged: (v) {
+                    setState(() => _soundEnabled = v);
+                    _saveSetting('sound_enabled', v);
                   },
+                  colorScheme: colorScheme,
                 ),
-                Divider(height: 1, color: Theme.of(context).colorScheme.outline),
-                _buildSwitchTile(
-                  icon: Icons.vibration,
-                  title: 'Vibration',
-                  subtitle: 'Vibrate on notifications',
+                _divider(colorScheme),
+                _SwitchRow(
+                  icon: Icons.vibration_rounded,
+                  label: 'Vibration',
                   value: _vibrationEnabled,
-                  onChanged: (value) {
-                    setState(() => _vibrationEnabled = value);
-                    _saveSetting('vibration_enabled', value);
+                  onChanged: (v) {
+                    setState(() => _vibrationEnabled = v);
+                    _saveSetting('vibration_enabled', v);
                   },
+                  colorScheme: colorScheme,
                 ),
               ],
             ),
-            // App Preferences Section
-            _buildSettingsSection(
-              title: 'App Preferences',
+
+            const SizedBox(height: 24),
+
+            // ── Appearance ────────────────────────────────────────────
+            _sectionHeader('Appearance', colorScheme),
+
+            _GroupedCard(
+              theme: theme,
+              colorScheme: colorScheme,
               children: [
-                _buildActionTile(
-                  icon: Icons.language,
-                  title: 'Language',
-                  subtitle: _language,
-                  onTap: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Language selection coming soon'),
-                        backgroundColor: Theme.of(context).colorScheme.primary,
-                      ),
-                    );
+                _SwitchRow(
+                  icon: Icons.dark_mode_rounded,
+                  label: 'Dark Mode',
+                  value: _darkMode,
+                  onChanged: (v) {
+                    setState(() => _darkMode = v);
+                    _saveSetting('dark_mode', v);
                   },
-                ),
-                Divider(height: 1, color: Theme.of(context).colorScheme.outline),
-                _buildActionTile(
-                  icon: Icons.info,
-                  title: 'About',
-                  subtitle: 'Version 1.0.0+3',
-                  onTap: () {
-                    showDialog(
-                      context: context,
-                      builder: (context) => AlertDialog(
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        title: Row(
-                          children: [
-                            Icon(Icons.bus_alert,
-                                color: Theme.of(context).colorScheme.primary),
-                            SizedBox(width: 2.w),
-                            Text('About ApoBasi'),
-                          ],
-                        ),
-                        content: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text('Version: 1.0.0+3'),
-                            SizedBox(height: 1.h),
-                            Text('© 2026 ApoBasi - Powered by SoG'),
-                            SizedBox(height: 1.h),
-                            Text(
-                              'School bus tracking and attendance management for African schools.',
-                              style: TextStyle(fontSize: 13),
-                            ),
-                          ],
-                        ),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.pop(context),
-                            child: Text('Close'),
-                          ),
-                        ],
-                      ),
-                    );
-                  },
-                ),
-                Divider(height: 1, color: Theme.of(context).colorScheme.outline),
-                _buildActionTile(
-                  icon: Icons.privacy_tip,
-                  title: 'Privacy Policy',
-                  subtitle: 'View our privacy policy',
-                  onTap: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Privacy policy will be displayed here'),
-                        backgroundColor: Theme.of(context).colorScheme.primary,
-                      ),
-                    );
-                  },
+                  colorScheme: colorScheme,
                 ),
               ],
             ),
 
-            SizedBox(height: 2.h),
+            const SizedBox(height: 24),
 
-            // Footer
-            Text(
-              '© 2026 ApoBasi - Powered by SoG',
-              style: TextStyle(
-                fontSize: 12,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-              textAlign: TextAlign.center,
+            // ── About ─────────────────────────────────────────────────
+            _sectionHeader('About', colorScheme),
+
+            _GroupedCard(
+              theme: theme,
+              colorScheme: colorScheme,
+              children: [
+                _NavRow(
+                  icon: Icons.info_outline_rounded,
+                  label: 'About ApoBasi',
+                  subtitle: 'Version 1.0.0+3',
+                  onTap: _showAboutDialog,
+                  colorScheme: colorScheme,
+                ),
+                _divider(colorScheme),
+                _NavRow(
+                  icon: Icons.shield_outlined,
+                  label: 'Privacy Policy',
+                  onTap: () {},
+                  colorScheme: colorScheme,
+                ),
+              ],
             ),
-            SizedBox(height: 2.h),
+
+            const SizedBox(height: 40),
+
+            Center(
+              child: Text(
+                '© 2026 ApoBasi – Powered by SoG',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionHeader(String title, ColorScheme colorScheme) => Padding(
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 10),
+        child: Text(
+          title,
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+            color: colorScheme.onSurface,
+          ),
+        ),
+      );
+
+  Widget _divider(ColorScheme colorScheme) => Divider(
+        height: 1,
+        indent: 16,
+        endIndent: 16,
+        color: colorScheme.outline.withValues(alpha: 0.5),
+      );
+}
+
+// ── Sub-widgets ───────────────────────────────────────────────────────────────
+
+class _GroupedCard extends StatelessWidget {
+  final ThemeData theme;
+  final ColorScheme colorScheme;
+  final List<Widget> children;
+
+  const _GroupedCard({
+    required this.theme,
+    required this.colorScheme,
+    required this.children,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      decoration: BoxDecoration(
+        color: theme.cardColor,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: colorScheme.outline),
+      ),
+      child: Column(children: children),
+    );
+  }
+}
+
+class _SwitchRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final ColorScheme colorScheme;
+
+  const _SwitchRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    required this.colorScheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: colorScheme.onSurfaceVariant),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Text(
+              label,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w400,
+                color: colorScheme.onSurface,
+              ),
+            ),
+          ),
+          Switch(
+            value: value,
+            onChanged: onChanged,
+            activeColor: colorScheme.primary,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NavRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String? subtitle;
+  final VoidCallback onTap;
+  final ColorScheme colorScheme;
+
+  const _NavRow({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    required this.colorScheme,
+    this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(10),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        child: Row(
+          children: [
+            Icon(icon, size: 20, color: colorScheme.onSurfaceVariant),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w400,
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                  if (subtitle != null)
+                    Text(
+                      subtitle!,
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right,
+                size: 20, color: colorScheme.onSurfaceVariant),
           ],
         ),
       ),

--- a/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
@@ -41,6 +41,8 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   bool _hasActiveTrip = false;
   Map<String, dynamic>? _activeTripInfo;
 
+  bool _isStudentsExpanded = false;
+
   // Attendance-focused readiness checks
   final Map<int, bool> _readinessStates = {};
 
@@ -372,7 +374,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
       builder: (context) => Container(
         padding: EdgeInsets.all(6.w),
         decoration: BoxDecoration(
-            color: Colors.white,
+            color: Theme.of(context).cardColor,
             borderRadius: BorderRadius.vertical(top: Radius.circular(24))),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -460,12 +462,15 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        backgroundColor: Color(0xFFF8F9FB),
+    return Theme(
+      data: AppTheme.lightBusminderTheme,
+      child: Scaffold(
+        backgroundColor: AppTheme.lightBusminderTheme.scaffoldBackgroundColor,
         drawer: BusminderDrawerWidget(
             currentRoute: '/busminder-start-shift-screen'),
         body: _isLoadingData ? _buildLoadingState() : _buildMainContent(),
-      );
+      ),
+    );
   }
 
   Widget _buildLoadingState() {
@@ -533,13 +538,13 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                     width: 48,
                     height: 48,
                     decoration: BoxDecoration(
-                      color: Colors.white,
+                      color: Theme.of(context).cardColor,
                       shape: BoxShape.circle,
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withOpacity(0.08),
+                          color: Colors.black.withValues(alpha: 0.08),
                           blurRadius: 8,
-                          offset: Offset(0, 2),
+                          offset: const Offset(0, 2),
                         ),
                       ],
                     ),
@@ -591,91 +596,81 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   }
 
   Widget _buildGreetingCard(String name) {
+    final cs = Theme.of(context).colorScheme;
+    final statusColor = _hasActiveTrip ? cs.secondary : cs.primary;
+    final statusLabel = _hasActiveTrip ? 'Attendance Active' : 'Ready for Attendance';
+
     return Container(
       padding: EdgeInsets.all(5.w),
       decoration: BoxDecoration(
-          color: Colors.white,
+          color: Theme.of(context).cardColor,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
-                color: Colors.black.withOpacity(0.04),
+                color: Colors.black.withValues(alpha: 0.04),
                 blurRadius: 20,
-                offset: Offset(0, 4))
+                offset: const Offset(0, 4))
           ]),
       child: Row(
         children: [
           Expanded(
-            child:
-                Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
               Text(_getGreeting(),
                   style: TextStyle(
                       fontSize: 14,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      color: cs.onSurfaceVariant,
                       fontWeight: FontWeight.w500)),
-              SizedBox(height: 4),
+              const SizedBox(height: 4),
               Text(name.split(' ').first,
                   style: TextStyle(
                       fontSize: 24,
                       fontWeight: FontWeight.w700,
-                      color: Theme.of(context).colorScheme.onSurface,
+                      color: cs.onSurface,
                       letterSpacing: -0.5)),
-              SizedBox(height: 8),
+              const SizedBox(height: 8),
               Container(
-                padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
                 decoration: BoxDecoration(
-                    color: _hasActiveTrip
-                        ? Theme.of(context).colorScheme.secondary.withOpacity(0.1)
-                        : Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                    color: statusColor.withValues(alpha: 0.1),
                     borderRadius: BorderRadius.circular(20)),
                 child: Row(mainAxisSize: MainAxisSize.min, children: [
                   Container(
                       width: 6,
                       height: 6,
                       decoration: BoxDecoration(
-                          color: _hasActiveTrip
-                              ? Theme.of(context).colorScheme.secondary
-                              : Theme.of(context).colorScheme.primary,
+                          color: statusColor,
                           shape: BoxShape.circle)),
-                  SizedBox(width: 6),
-                  Text(
-                      _hasActiveTrip
-                          ? 'Attendance Active'
-                          : 'Ready for Attendance',
+                  const SizedBox(width: 6),
+                  Text(statusLabel,
                       style: TextStyle(
                           fontSize: 12,
                           fontWeight: FontWeight.w600,
-                          color: _hasActiveTrip
-                              ? Theme.of(context).colorScheme.secondary
-                              : Theme.of(context).colorScheme.primary)),
+                          color: statusColor)),
                 ]),
               ),
             ]),
           ),
-          // Attendance clipboard icon for bus minder
           Container(
               width: 56,
               height: 56,
               decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                  color: cs.primary.withValues(alpha: 0.08),
                   borderRadius: BorderRadius.circular(16)),
-              child: Icon(Icons.assignment_outlined,
-                  size: 28, color: Theme.of(context).colorScheme.primary)),
+              child: Icon(Icons.assignment_outlined, size: 28, color: cs.primary)),
         ],
       ),
     );
   }
 
   Widget _buildSectionTitle(String title, IconData icon) {
-    return Row(children: [
-      Icon(icon, size: 18, color: Theme.of(context).colorScheme.onSurfaceVariant),
-      SizedBox(width: 8),
-      Text(title,
-          style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-              letterSpacing: 0.5))
-    ]);
+    return Text(
+      title,
+      style: TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.w700,
+        color: Theme.of(context).colorScheme.onSurface,
+      ),
+    );
   }
 
   Widget _buildNotAssignedCard() {
@@ -711,28 +706,26 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   }
 
   Widget _buildAssignmentCard() {
+    final cs = Theme.of(context).colorScheme;
     return Container(
       padding: EdgeInsets.all(5.w),
       decoration: BoxDecoration(
-          color: Colors.white,
+          color: Theme.of(context).cardColor,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
-                color: Colors.black.withOpacity(0.04),
+                color: Colors.black.withValues(alpha: 0.04),
                 blurRadius: 20,
-                offset: Offset(0, 4))
+                offset: const Offset(0, 4))
           ]),
       child: Column(children: [
         Row(children: [
           Container(
-              padding: EdgeInsets.all(12),
+              padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                  gradient: LinearGradient(colors: [
-                    Theme.of(context).colorScheme.primary,
-                    Theme.of(context).colorScheme.primary.withOpacity(0.7)
-                  ]),
-                  borderRadius: BorderRadius.circular(12)),
-              child: Icon(Icons.directions_bus_rounded,
+                  color: cs.primary,
+                  borderRadius: BorderRadius.circular(14)),
+              child: const Icon(Icons.directions_bus_rounded,
                   size: 24, color: Colors.white)),
           SizedBox(width: 4.w),
           Expanded(
@@ -743,10 +736,9 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                     style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w700,
-                        color: Theme.of(context).colorScheme.onSurface)),
+                        color: cs.onSurface)),
                 Text('Assigned Bus',
-                    style:
-                        TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.onSurfaceVariant)),
+                    style: TextStyle(fontSize: 14, color: cs.onSurfaceVariant)),
               ])),
         ]),
         SizedBox(height: 3.h),
@@ -762,15 +754,16 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   }
 
   Widget _buildInfoPill(IconData icon, String value, String label) {
+    final cs = Theme.of(context).colorScheme;
     return Expanded(
       child: Container(
-        padding: EdgeInsets.all(12),
+        padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.primary.withOpacity(0.05),
+            color: cs.primary.withValues(alpha: 0.05),
             borderRadius: BorderRadius.circular(12)),
         child: Row(children: [
-          Icon(icon, size: 20, color: Theme.of(context).colorScheme.primary),
-          SizedBox(width: 8),
+          Icon(icon, size: 20, color: cs.primary),
+          const SizedBox(width: 8),
           Expanded(
             child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -780,11 +773,10 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                       style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w700,
-                          color: Theme.of(context).colorScheme.onSurface),
+                          color: cs.onSurface),
                       overflow: TextOverflow.ellipsis),
                   Text(label,
-                      style: TextStyle(
-                          fontSize: 11, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                      style: TextStyle(fontSize: 11, color: cs.onSurfaceVariant),
                       overflow: TextOverflow.ellipsis),
                 ]),
           ),
@@ -794,74 +786,165 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   }
 
   Widget _buildStudentPreviewCard() {
+    final cs = Theme.of(context).colorScheme;
     final totalStudents = _assignedChildren.length;
 
     if (totalStudents == 0) {
       return Container(
         padding: EdgeInsets.all(5.w),
         decoration: BoxDecoration(
-            color: Colors.white,
+            color: Theme.of(context).cardColor,
             borderRadius: BorderRadius.circular(16),
-            boxShadow: [
-              BoxShadow(
-                  color: Colors.black.withOpacity(0.04),
-                  blurRadius: 12,
-                  offset: Offset(0, 4))
-            ]),
+            border: Border.all(color: cs.outline.withValues(alpha: 0.5))),
         child: Column(children: [
-          Icon(Icons.people_outline, size: 40, color: Colors.grey.shade300),
+          Icon(Icons.people_outline,
+              size: 40, color: cs.onSurfaceVariant.withValues(alpha: 0.4)),
           SizedBox(height: 1.h),
           Text('No students assigned',
-              style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
+              style: TextStyle(color: cs.onSurfaceVariant)),
         ]),
       );
     }
 
+    final displayChildren =
+        totalStudents > 5 ? _assignedChildren.sublist(0, 5) : _assignedChildren;
+    final remaining = totalStudents - displayChildren.length;
+
     return Container(
-      padding: EdgeInsets.all(5.w),
       decoration: BoxDecoration(
-          color: Colors.white,
+          color: Theme.of(context).cardColor,
           borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-                color: Colors.black.withOpacity(0.04),
-                blurRadius: 12,
-                offset: Offset(0, 4))
-          ]),
+          border: Border.all(color: cs.outline.withValues(alpha: 0.5))),
+      child: Column(
+        children: [
+          // Collapsible header
+          InkWell(
+            onTap: () => setState(() => _isStudentsExpanded = !_isStudentsExpanded),
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(16),
+              topRight: Radius.circular(16),
+              bottomLeft: Radius.circular(_isStudentsExpanded ? 0 : 16),
+              bottomRight: Radius.circular(_isStudentsExpanded ? 0 : 16),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              child: Row(
+                children: [
+                  Container(
+                    width: 36,
+                    height: 36,
+                    decoration: BoxDecoration(
+                        color: cs.primary.withValues(alpha: 0.1),
+                        shape: BoxShape.circle),
+                    child: Icon(Icons.people_outline, size: 20, color: cs.primary),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Assigned Students',
+                            style: TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.w600,
+                                color: cs.onSurface)),
+                        Text('$totalStudents students',
+                            style: TextStyle(
+                                fontSize: 12, color: cs.onSurfaceVariant)),
+                      ],
+                    ),
+                  ),
+                  AnimatedRotation(
+                    turns: _isStudentsExpanded ? 0.5 : 0,
+                    duration: const Duration(milliseconds: 200),
+                    child: Icon(Icons.expand_more, color: cs.onSurfaceVariant),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          // Expandable list
+          AnimatedCrossFade(
+            firstChild: const SizedBox.shrink(),
+            secondChild: Column(
+              children: [
+                Divider(height: 1, color: cs.outline.withValues(alpha: 0.4)),
+                for (int i = 0; i < displayChildren.length; i++) ...[
+                  if (i > 0)
+                    Divider(
+                        height: 1,
+                        indent: 16,
+                        endIndent: 16,
+                        color: cs.outline.withValues(alpha: 0.4)),
+                  _buildStudentRow(displayChildren[i], cs),
+                ],
+                if (remaining > 0) ...[
+                  Divider(
+                      height: 1,
+                      indent: 16,
+                      endIndent: 16,
+                      color: cs.outline.withValues(alpha: 0.4)),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    child: Text('+$remaining more students',
+                        style: TextStyle(
+                            fontSize: 13, color: cs.onSurfaceVariant)),
+                  ),
+                ],
+              ],
+            ),
+            crossFadeState: _isStudentsExpanded
+                ? CrossFadeState.showSecond
+                : CrossFadeState.showFirst,
+            duration: const Duration(milliseconds: 200),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStudentRow(Map<String, dynamic> student, ColorScheme cs) {
+    final name = student['name'] as String? ?? 'Student';
+    final grade = student['grade'] as String? ?? 'N/A';
+    final initials = _getInitials(name);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(
         children: [
           Container(
-            padding: EdgeInsets.all(3.w),
+            width: 40,
+            height: 40,
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.08),
-              borderRadius: BorderRadius.circular(12),
+                color: cs.primary.withValues(alpha: 0.12),
+                shape: BoxShape.circle),
+            child: Center(
+              child: Text(initials,
+                  style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: cs.primary)),
             ),
-            child: Icon(Icons.people_outline,
-                color: Theme.of(context).colorScheme.primary, size: 24),
           ),
-          SizedBox(width: 4.w),
+          const SizedBox(width: 12),
           Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Assigned Students',
-                  style: TextStyle(
-                    fontSize: 16,
+            child: Text(name,
+                style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                    color: cs.onSurface)),
+          ),
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+                color: cs.primary.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(20)),
+            child: Text('Gr $grade',
+                style: TextStyle(
+                    fontSize: 12,
                     fontWeight: FontWeight.w600,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                ),
-                SizedBox(height: 0.5.h),
-                Text(
-                  '$totalStudents students',
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
+                    color: cs.primary)),
           ),
         ],
       ),
@@ -913,7 +996,9 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
         duration: const Duration(milliseconds: 200),
         padding: EdgeInsets.all(3.5.w),
         decoration: BoxDecoration(
-          color: isSelected ? color.withOpacity(0.1) : Colors.white,
+          color: isSelected
+              ? color.withValues(alpha: 0.1)
+              : Theme.of(context).cardColor,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(
             color: isSelected ? color : Theme.of(context).colorScheme.outline,
@@ -922,7 +1007,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
           boxShadow: isSelected
               ? [
                   BoxShadow(
-                    color: color.withOpacity(0.12),
+                    color: color.withValues(alpha: 0.12),
                     blurRadius: 12,
                     offset: const Offset(0, 4),
                   ),
@@ -934,7 +1019,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
             Container(
               padding: EdgeInsets.all(2.5.w),
               decoration: BoxDecoration(
-                color: color.withOpacity(0.12),
+                color: color.withValues(alpha: 0.12),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Icon(icon, size: 22, color: color),
@@ -977,12 +1062,14 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
 
     return Container(
       padding: EdgeInsets.all(5.w),
-      decoration: BoxDecoration(color: Colors.white, boxShadow: [
-        BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 10,
-            offset: Offset(0, -5))
-      ]),
+      decoration: BoxDecoration(
+          color: Theme.of(context).cardColor,
+          boxShadow: [
+            BoxShadow(
+                color: Colors.black.withValues(alpha: 0.05),
+                blurRadius: 10,
+                offset: const Offset(0, -5))
+          ]),
       child: SafeArea(
         top: false,
         child: AnimatedBuilder(
@@ -1008,7 +1095,10 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                               ? Theme.of(context).colorScheme.secondary
                               : Theme.of(context).colorScheme.primary,
                           _hasActiveTrip
-                              ? Theme.of(context).colorScheme.secondary.withOpacity(0.8)
+                              ? Theme.of(context)
+                                  .colorScheme
+                                  .secondary
+                                  .withValues(alpha: 0.8)
                               : Theme.of(context).colorScheme.primaryContainer,
                         ])
                       : null,
@@ -1020,9 +1110,9 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                             color: (_hasActiveTrip
                                     ? Theme.of(context).colorScheme.secondary
                                     : Theme.of(context).colorScheme.primary)
-                                .withOpacity(0.4),
+                                .withValues(alpha: 0.4),
                             blurRadius: 12,
-                            offset: Offset(0, 4),
+                            offset: const Offset(0, 4),
                           ),
                         ]
                       : null,

--- a/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
@@ -121,7 +121,9 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
           if (backendTrip != null && status == 'in-progress') {
             final prefs = await SharedPreferences.getInstance();
             await prefs.setInt('current_trip_id', backendTrip['id']);
-          } else if (backendTrip != null && status != null) {
+          } else {
+            // No active trip on backend (null response or non-in-progress status)
+            // — clear stale local state so "Continue Trip" stops showing
             await _clearStaleLocalTripState();
             if (mounted) {
               setState(() {
@@ -131,7 +133,18 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
             }
           }
         } catch (_) {
-          // Keep local trip state when backend check fails
+          // Backend unreachable — trust local state only if there is an actual trip ID
+          final prefs = await SharedPreferences.getInstance();
+          final hasTripId = (prefs.getInt('current_trip_id') ?? 0) > 0;
+          if (!hasTripId) {
+            await _clearStaleLocalTripState();
+            if (mounted) {
+              setState(() {
+                _hasActiveTrip = false;
+                _activeTripInfo = null;
+              });
+            }
+          }
         }
       } else {
         setState(() {

--- a/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
@@ -8,6 +8,7 @@ import 'package:sizer/sizer.dart';
 
 import '../../core/app_export.dart';
 import '../../services/api_service.dart';
+import '../../services/theme_service.dart';
 import '../../services/trip_state_service.dart';
 import '../../theme/app_theme.dart';
 import '../../widgets/busminder_drawer_widget.dart';
@@ -42,6 +43,9 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   Map<String, dynamic>? _activeTripInfo;
 
   bool _isStudentsExpanded = false;
+
+  // Busminder theme — set in build() so helper methods always use the right theme
+  ThemeData _busminderTheme = AppTheme.lightBusminderTheme;
 
   // Attendance-focused readiness checks
   final Map<int, bool> _readinessStates = {};
@@ -320,7 +324,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: const Text('No bus assigned. Cannot start attendance.'),
-              backgroundColor: Theme.of(context).colorScheme.error,
+              backgroundColor: _busminderTheme.colorScheme.error,
             ),
           );
         }
@@ -361,7 +365,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
               content: Text('Failed to start attendance: ${e.toString()}'),
-              backgroundColor: Theme.of(context).colorScheme.error),
+              backgroundColor: _busminderTheme.colorScheme.error),
         );
       }
     }
@@ -374,7 +378,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
       builder: (context) => Container(
         padding: EdgeInsets.all(6.w),
         decoration: BoxDecoration(
-            color: Theme.of(context).cardColor,
+            color: _busminderTheme.cardColor,
             borderRadius: BorderRadius.vertical(top: Radius.circular(24))),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -387,18 +391,18 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                     borderRadius: BorderRadius.circular(2))),
             SizedBox(height: 3.h),
             Icon(Icons.warning_amber_rounded,
-                size: 48, color: Theme.of(context).colorScheme.tertiary),
+                size: 48, color: _busminderTheme.colorScheme.tertiary),
             SizedBox(height: 2.h),
             Text('Reset Shift State?',
                 style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.w700,
-                    color: Theme.of(context).colorScheme.onSurface)),
+                    color: _busminderTheme.colorScheme.onSurface)),
             SizedBox(height: 1.h),
             Text(
                 'This will clear local attendance data. Only use if the app is stuck.',
                 textAlign: TextAlign.center,
-                style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
+                style: TextStyle(color: _busminderTheme.colorScheme.onSurfaceVariant)),
             SizedBox(height: 3.h),
             Row(
               children: [
@@ -410,7 +414,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                             shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.circular(12))),
                         child: Text('Cancel',
-                            style: TextStyle(color: Theme.of(context).colorScheme.onSurface)))),
+                            style: TextStyle(color: _busminderTheme.colorScheme.onSurface)))),
                 SizedBox(width: 4.w),
                 Expanded(
                     child: ElevatedButton(
@@ -423,10 +427,10 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                     });
                     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         content: Text('Shift state reset'),
-                        backgroundColor: Theme.of(context).colorScheme.secondary));
+                        backgroundColor: _busminderTheme.colorScheme.secondary));
                   },
                   style: ElevatedButton.styleFrom(
-                      backgroundColor: Theme.of(context).colorScheme.tertiary,
+                      backgroundColor: _busminderTheme.colorScheme.tertiary,
                       padding: EdgeInsets.symmetric(vertical: 14),
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12)),
@@ -462,14 +466,22 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      data: AppTheme.lightBusminderTheme,
-      child: Scaffold(
-        backgroundColor: AppTheme.lightBusminderTheme.scaffoldBackgroundColor,
-        drawer: BusminderDrawerWidget(
-            currentRoute: '/busminder-start-shift-screen'),
-        body: _isLoadingData ? _buildLoadingState() : _buildMainContent(),
-      ),
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: ThemeService().themeModeNotifier,
+      builder: (ctx, themeMode, _) {
+        _busminderTheme = themeMode == ThemeMode.dark
+            ? AppTheme.darkBusminderTheme
+            : AppTheme.lightBusminderTheme;
+        return Theme(
+          data: _busminderTheme,
+          child: Scaffold(
+            backgroundColor: _busminderTheme.scaffoldBackgroundColor,
+            drawer: const BusminderDrawerWidget(
+                currentRoute: '/busminder-start-shift-screen'),
+            body: _isLoadingData ? _buildLoadingState() : _buildMainContent(),
+          ),
+        );
+      },
     );
   }
 
@@ -477,9 +489,9 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
     return Center(
       child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
         CircularProgressIndicator(
-            color: Theme.of(context).colorScheme.primary, strokeWidth: 3),
+            color: _busminderTheme.colorScheme.primary, strokeWidth: 3),
         SizedBox(height: 2.h),
-        Text('Loading...', style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
+        Text('Loading...', style: TextStyle(color: _busminderTheme.colorScheme.onSurfaceVariant)),
       ]),
     );
   }
@@ -488,179 +500,108 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
     final name = _minderData?['minderName'] as String? ?? 'Assistant';
 
     return SafeArea(
-      child: Stack(
+      child: Column(
         children: [
-          Column(
-            children: [
-              SizedBox(height: 2.h),
-              Expanded(
-                child: SingleChildScrollView(
-                  physics: BouncingScrollPhysics(),
-                  padding: EdgeInsets.symmetric(horizontal: 5.w),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      _buildGreetingCard(name),
-                      SizedBox(height: 3.h),
-                      if (_minderData?['isAssigned'] != true)
-                        _buildNotAssignedCard()
-                      else ...[
-                        _buildAssignmentCard(),
-                        SizedBox(height: 3.h),
-                      ],
-                      _buildSectionTitle(
-                          'Students Preview', Icons.people_outline),
-                      SizedBox(height: 1.5.h),
-                      _buildStudentPreviewCard(),
-                      SizedBox(height: 3.h),
-                      _buildSectionTitle(
-                          'Attendance Type', Icons.swap_vert_rounded),
-                      SizedBox(height: 1.5.h),
-                      _buildAttendanceTypeSelector(),
-                      SizedBox(height: 4.h),
-                    ],
-                  ),
-                ),
-              ),
-              _buildBottomButton(),
-            ],
-          ),
-          Positioned(
-            top: 12,
-            left: 12,
-            child: Builder(
-              builder: (context) => Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(30),
-                  onTap: () => Scaffold.of(context).openDrawer(),
-                  child: Container(
-                    width: 48,
-                    height: 48,
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).cardColor,
-                      shape: BoxShape.circle,
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.08),
-                          blurRadius: 8,
-                          offset: const Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: Icon(Icons.menu_rounded,
-                        color: Theme.of(context).colorScheme.onSurface, size: 28),
-                  ),
-                ),
+          _buildTopHeader(name),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              padding: EdgeInsets.symmetric(horizontal: 5.w),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(height: 2.h),
+                  if (_minderData?['isAssigned'] != true)
+                    _buildNotAssignedCard()
+                  else ...[
+                    _buildAssignmentCard(),
+                    SizedBox(height: 3.h),
+                  ],
+                  _buildSectionTitle('Students Preview', Icons.people_outline),
+                  SizedBox(height: 1.5.h),
+                  _buildStudentPreviewCard(),
+                  SizedBox(height: 3.h),
+                  _buildSectionTitle(
+                      'Attendance Type', Icons.swap_vert_rounded),
+                  SizedBox(height: 1.5.h),
+                  _buildAttendanceTypeSelector(),
+                  SizedBox(height: 4.h),
+                ],
               ),
             ),
           ),
+          _buildBottomButton(),
         ],
       ),
     );
   }
 
-  Widget _buildTopBar(String name) {
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 5.w, vertical: 2.h),
+  Widget _buildTopHeader(String name) {
+    final cs = _busminderTheme.colorScheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(5.w, 1.5.h, 5.w, 1.h),
       child: Row(
         children: [
           Builder(
-            builder: (context) => IconButton(
-              icon: Icon(Icons.menu_rounded,
-                  color: Theme.of(context).colorScheme.onSurface, size: 28),
-              onPressed: () => Scaffold.of(context).openDrawer(),
-              tooltip: 'Open navigation drawer',
+            builder: (context) => GestureDetector(
+              onTap: () => Scaffold.of(context).openDrawer(),
+              child: Icon(Icons.menu_rounded, size: 28, color: cs.onSurface),
             ),
           ),
-          Spacer(),
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-            decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(20)),
-            child: Row(mainAxisSize: MainAxisSize.min, children: [
-              Icon(Icons.access_time,
-                  size: 16, color: Theme.of(context).colorScheme.primary),
-              SizedBox(width: 6),
-              Text(_currentTime,
-                  style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: Theme.of(context).colorScheme.primary)),
-            ]),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildGreetingCard(String name) {
-    final cs = Theme.of(context).colorScheme;
-    final statusColor = _hasActiveTrip ? cs.secondary : cs.primary;
-    final statusLabel = _hasActiveTrip ? 'Attendance Active' : 'Ready for Attendance';
-
-    return Container(
-      padding: EdgeInsets.all(5.w),
-      decoration: BoxDecoration(
-          color: Theme.of(context).cardColor,
-          borderRadius: BorderRadius.circular(20),
-          boxShadow: [
-            BoxShadow(
-                color: Colors.black.withValues(alpha: 0.04),
-                blurRadius: 20,
-                offset: const Offset(0, 4))
-          ]),
-      child: Row(
-        children: [
+          SizedBox(width: 4.w),
           Expanded(
-            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              Text(_getGreeting(),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _getGreeting(),
                   style: TextStyle(
-                      fontSize: 14,
+                      fontSize: 13,
                       color: cs.onSurfaceVariant,
-                      fontWeight: FontWeight.w500)),
-              const SizedBox(height: 4),
-              Text(name.split(' ').first,
+                      fontWeight: FontWeight.w400),
+                ),
+                Text(
+                  name.split(' ').first,
                   style: TextStyle(
-                      fontSize: 24,
+                      fontSize: 22,
                       fontWeight: FontWeight.w700,
                       color: cs.onSurface,
-                      letterSpacing: -0.5)),
-              const SizedBox(height: 8),
+                      letterSpacing: -0.5),
+                ),
+              ],
+            ),
+          ),
+          // Time pill
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            decoration: BoxDecoration(
+              color: cs.primary.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: cs.primary.withValues(alpha: 0.25)),
+            ),
+            child: Row(mainAxisSize: MainAxisSize.min, children: [
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-                decoration: BoxDecoration(
-                    color: statusColor.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(20)),
-                child: Row(mainAxisSize: MainAxisSize.min, children: [
-                  Container(
-                      width: 6,
-                      height: 6,
-                      decoration: BoxDecoration(
-                          color: statusColor,
-                          shape: BoxShape.circle)),
-                  const SizedBox(width: 6),
-                  Text(statusLabel,
-                      style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                          color: statusColor)),
-                ]),
+                width: 8,
+                height: 8,
+                decoration:
+                    BoxDecoration(color: cs.primary, shape: BoxShape.circle),
+              ),
+              const SizedBox(width: 6),
+              Text(
+                _currentTime,
+                style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: cs.primary),
               ),
             ]),
           ),
-          Container(
-              width: 56,
-              height: 56,
-              decoration: BoxDecoration(
-                  color: cs.primary.withValues(alpha: 0.08),
-                  borderRadius: BorderRadius.circular(16)),
-              child: Icon(Icons.assignment_outlined, size: 28, color: cs.primary)),
         ],
       ),
     );
   }
+
 
   Widget _buildSectionTitle(String title, IconData icon) {
     return Text(
@@ -668,7 +609,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
       style: TextStyle(
         fontSize: 18,
         fontWeight: FontWeight.w700,
-        color: Theme.of(context).colorScheme.onSurface,
+        color: _busminderTheme.colorScheme.onSurface,
       ),
     );
   }
@@ -706,11 +647,11 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   }
 
   Widget _buildAssignmentCard() {
-    final cs = Theme.of(context).colorScheme;
+    final cs = _busminderTheme.colorScheme;
     return Container(
       padding: EdgeInsets.all(5.w),
       decoration: BoxDecoration(
-          color: Theme.of(context).cardColor,
+          color: _busminderTheme.cardColor,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
@@ -754,7 +695,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   }
 
   Widget _buildInfoPill(IconData icon, String value, String label) {
-    final cs = Theme.of(context).colorScheme;
+    final cs = _busminderTheme.colorScheme;
     return Expanded(
       child: Container(
         padding: const EdgeInsets.all(12),
@@ -786,14 +727,14 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
   }
 
   Widget _buildStudentPreviewCard() {
-    final cs = Theme.of(context).colorScheme;
+    final cs = _busminderTheme.colorScheme;
     final totalStudents = _assignedChildren.length;
 
     if (totalStudents == 0) {
       return Container(
         padding: EdgeInsets.all(5.w),
         decoration: BoxDecoration(
-            color: Theme.of(context).cardColor,
+            color: _busminderTheme.cardColor,
             borderRadius: BorderRadius.circular(16),
             border: Border.all(color: cs.outline.withValues(alpha: 0.5))),
         child: Column(children: [
@@ -806,23 +747,20 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
       );
     }
 
-    final displayChildren =
-        totalStudents > 5 ? _assignedChildren.sublist(0, 5) : _assignedChildren;
-    final remaining = totalStudents - displayChildren.length;
-
     return Container(
       decoration: BoxDecoration(
-          color: Theme.of(context).cardColor,
+          color: _busminderTheme.cardColor,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(color: cs.outline.withValues(alpha: 0.5))),
       child: Column(
         children: [
           // Collapsible header
           InkWell(
-            onTap: () => setState(() => _isStudentsExpanded = !_isStudentsExpanded),
+            onTap: () =>
+                setState(() => _isStudentsExpanded = !_isStudentsExpanded),
             borderRadius: BorderRadius.only(
-              topLeft: Radius.circular(16),
-              topRight: Radius.circular(16),
+              topLeft: const Radius.circular(16),
+              topRight: const Radius.circular(16),
               bottomLeft: Radius.circular(_isStudentsExpanded ? 0 : 16),
               bottomRight: Radius.circular(_isStudentsExpanded ? 0 : 16),
             ),
@@ -836,7 +774,8 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                     decoration: BoxDecoration(
                         color: cs.primary.withValues(alpha: 0.1),
                         shape: BoxShape.circle),
-                    child: Icon(Icons.people_outline, size: 20, color: cs.primary),
+                    child:
+                        Icon(Icons.people_outline, size: 20, color: cs.primary),
                   ),
                   const SizedBox(width: 12),
                   Expanded(
@@ -857,39 +796,27 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                   AnimatedRotation(
                     turns: _isStudentsExpanded ? 0.5 : 0,
                     duration: const Duration(milliseconds: 200),
-                    child: Icon(Icons.expand_more, color: cs.onSurfaceVariant),
+                    child:
+                        Icon(Icons.expand_more, color: cs.onSurfaceVariant),
                   ),
                 ],
               ),
             ),
           ),
-          // Expandable list
+          // Expandable list — shows ALL students
           AnimatedCrossFade(
             firstChild: const SizedBox.shrink(),
             secondChild: Column(
               children: [
                 Divider(height: 1, color: cs.outline.withValues(alpha: 0.4)),
-                for (int i = 0; i < displayChildren.length; i++) ...[
+                for (int i = 0; i < _assignedChildren.length; i++) ...[
                   if (i > 0)
                     Divider(
                         height: 1,
                         indent: 16,
                         endIndent: 16,
                         color: cs.outline.withValues(alpha: 0.4)),
-                  _buildStudentRow(displayChildren[i], cs),
-                ],
-                if (remaining > 0) ...[
-                  Divider(
-                      height: 1,
-                      indent: 16,
-                      endIndent: 16,
-                      color: cs.outline.withValues(alpha: 0.4)),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Text('+$remaining more students',
-                        style: TextStyle(
-                            fontSize: 13, color: cs.onSurfaceVariant)),
-                  ),
+                  _buildStudentRow(_assignedChildren[i], cs),
                 ],
               ],
             ),
@@ -940,7 +867,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
             decoration: BoxDecoration(
                 color: cs.primary.withValues(alpha: 0.08),
                 borderRadius: BorderRadius.circular(20)),
-            child: Text('Gr $grade',
+            child: Text(grade,
                 style: TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w600,
@@ -960,7 +887,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
             label: 'Pickup',
             subtitle: 'Morning',
             icon: Icons.wb_sunny_outlined,
-            color: Theme.of(context).colorScheme.primary,
+            color: _busminderTheme.colorScheme.primary,
           ),
         ),
         SizedBox(width: 3.w),
@@ -998,10 +925,10 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
         decoration: BoxDecoration(
           color: isSelected
               ? color.withValues(alpha: 0.1)
-              : Theme.of(context).cardColor,
+              : _busminderTheme.cardColor,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(
-            color: isSelected ? color : Theme.of(context).colorScheme.outline,
+            color: isSelected ? color : _busminderTheme.colorScheme.outline,
             width: 1.5,
           ),
           boxShadow: isSelected
@@ -1034,7 +961,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                     style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
-                      color: Theme.of(context).colorScheme.onSurface,
+                      color: _busminderTheme.colorScheme.onSurface,
                     ),
                   ),
                   SizedBox(height: 0.3.h),
@@ -1042,7 +969,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                     subtitle,
                     style: TextStyle(
                       fontSize: 12,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      color: _busminderTheme.colorScheme.onSurfaceVariant,
                     ),
                   ),
                 ],
@@ -1063,7 +990,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
     return Container(
       padding: EdgeInsets.all(5.w),
       decoration: BoxDecoration(
-          color: Theme.of(context).cardColor,
+          color: _busminderTheme.cardColor,
           boxShadow: [
             BoxShadow(
                 color: Colors.black.withValues(alpha: 0.05),
@@ -1092,14 +1019,14 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                   gradient: canStart
                       ? LinearGradient(colors: [
                           _hasActiveTrip
-                              ? Theme.of(context).colorScheme.secondary
-                              : Theme.of(context).colorScheme.primary,
+                              ? _busminderTheme.colorScheme.secondary
+                              : _busminderTheme.colorScheme.primary,
                           _hasActiveTrip
                               ? Theme.of(context)
                                   .colorScheme
                                   .secondary
                                   .withValues(alpha: 0.8)
-                              : Theme.of(context).colorScheme.primaryContainer,
+                              : _busminderTheme.colorScheme.primaryContainer,
                         ])
                       : null,
                   color: canStart ? null : Colors.grey.shade300,
@@ -1108,8 +1035,8 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
                       ? [
                           BoxShadow(
                             color: (_hasActiveTrip
-                                    ? Theme.of(context).colorScheme.secondary
-                                    : Theme.of(context).colorScheme.primary)
+                                    ? _busminderTheme.colorScheme.secondary
+                                    : _busminderTheme.colorScheme.primary)
                                 .withValues(alpha: 0.4),
                             blurRadius: 12,
                             offset: const Offset(0, 4),

--- a/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_start_shift_screen/busminder_start_shift_screen.dart
@@ -121,7 +121,7 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
         });
 
         try {
-          final backendTrip = await _apiService.getActiveTrip();
+          final backendTrip = await _apiService.getBusminderActiveTrip();
           final status = backendTrip?['status']?.toString().toLowerCase();
 
           if (backendTrip != null && status == 'in-progress') {
@@ -331,6 +331,18 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
         return;
       }
 
+      // POST to backend to create the trip
+      int? tripId;
+      try {
+        final tripResponse =
+            await _apiService.startBusminderTrip(tripType: tripType);
+        final tripData = tripResponse['trip'] as Map<String, dynamic>?;
+        tripId = tripData?['id'] as int?;
+      } catch (_) {
+        // Backend unreachable — proceed locally; trip_id will be missing
+        // but local attendance marking still works
+      }
+
       // Save using both key sets for compatibility
       await prefs.setInt('current_bus_id', busId);
       await prefs.setInt('bus_id', busId);
@@ -341,6 +353,10 @@ class _BusminderStartShiftScreenState extends State<BusminderStartShiftScreen>
       await prefs.setBool('trip_in_progress', true);
       await prefs.setBool('trip_active', true);
       await prefs.setString('bus_number', busNumber.toString());
+      if (tripId != null) {
+        await prefs.setInt('current_trip_id', tripId);
+        await prefs.setInt('trip_id', tripId);
+      }
 
       setState(() {
         _isLoading = false;

--- a/DriversandMinders/lib/presentation/busminder_trip_history_screen/busminder_trip_history_screen.dart
+++ b/DriversandMinders/lib/presentation/busminder_trip_history_screen/busminder_trip_history_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:sizer/sizer.dart';
 import '../../core/app_export.dart';
 import '../../services/api_service.dart';
+import '../../services/theme_service.dart';
+import '../../theme/app_theme.dart';
 
 class BusMinderTripHistoryScreen extends StatefulWidget {
   const BusMinderTripHistoryScreen({super.key});
@@ -14,6 +16,7 @@ class BusMinderTripHistoryScreen extends StatefulWidget {
 class _BusMinderTripHistoryScreenState
     extends State<BusMinderTripHistoryScreen> {
   final ApiService _apiService = ApiService();
+  ThemeData _busminderTheme = AppTheme.lightBusminderTheme;
   List<dynamic> _trips = [];
   bool _isLoading = true;
   String _selectedFilter = 'completed'; // completed, all
@@ -84,19 +87,28 @@ class _BusMinderTripHistoryScreenState
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (!didPop) {
-          _handleBackPress();
-        }
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: ThemeService().themeModeNotifier,
+      builder: (ctx, themeMode, _) {
+        _busminderTheme = themeMode == ThemeMode.dark
+            ? AppTheme.darkBusminderTheme
+            : AppTheme.lightBusminderTheme;
+        return Theme(
+          data: _busminderTheme,
+          child: PopScope(
+            canPop: false,
+            onPopInvokedWithResult: (didPop, result) async {
+              if (!didPop) _handleBackPress();
+            },
+            child: Scaffold(
+              backgroundColor: _busminderTheme.scaffoldBackgroundColor,
+              body: _showSummary && _tripSummary != null
+                  ? _buildModernSummaryView()
+                  : _buildLoadingView(),
+            ),
+          ),
+        );
       },
-      child: Scaffold(
-        backgroundColor: Color(0xFFF8FAFB),
-        body: _showSummary && _tripSummary != null
-            ? _buildModernSummaryView()
-            : _buildLoadingView(),
-      ),
     );
   }
 
@@ -107,6 +119,7 @@ class _BusMinderTripHistoryScreenState
   }
 
   Widget _buildModernSummaryView() {
+    final cs = _busminderTheme.colorScheme;
     final totalStudents = _tripSummary!['totalStudents'] ?? 0;
     final studentsCompleted = _tripSummary!['studentsCompleted'] ?? 0;
     final studentsAbsent = _tripSummary!['studentsAbsent'] ?? 0;
@@ -114,90 +127,84 @@ class _BusMinderTripHistoryScreenState
     final completionRate = totalStudents > 0
         ? ((studentsCompleted / totalStudents) * 100).round()
         : 0;
+    final isPickup = tripType == 'pickup';
 
     return SafeArea(
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 6.w),
-        child: Column(
-          children: [
-            SizedBox(height: 4.h),
-
-            // Success animation area
-            Expanded(
-              flex: 2,
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.symmetric(horizontal: 5.w),
               child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  // Animated check icon
+                  SizedBox(height: 5.h),
+
+                  // ── Success icon ──────────────────────────────────────────
                   Container(
-                    width: 100,
-                    height: 100,
+                    width: 96,
+                    height: 96,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      gradient: LinearGradient(
-                        colors: [
-                          Theme.of(context).colorScheme.secondary,
-                          Theme.of(context).colorScheme.secondary.withOpacity(0.8),
-                        ],
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                      ),
+                      color: cs.primary,
                       boxShadow: [
                         BoxShadow(
-                          color: Theme.of(context).colorScheme.secondary.withOpacity(0.3),
-                          blurRadius: 20,
-                          offset: Offset(0, 8),
+                          color: cs.primary.withValues(alpha: 0.35),
+                          blurRadius: 28,
+                          offset: const Offset(0, 10),
                         ),
                       ],
                     ),
-                    child: Icon(
-                      Icons.check_rounded,
-                      color: Colors.white,
-                      size: 56,
-                    ),
+                    child: const Icon(Icons.check_rounded,
+                        color: Colors.white, size: 52),
                   ),
+
                   SizedBox(height: 3.h),
+
+                  // ── Title ─────────────────────────────────────────────────
                   Text(
                     'Shift Complete!',
                     style: TextStyle(
-                      fontSize: 28,
+                      fontSize: 30,
                       fontWeight: FontWeight.w800,
-                      color: Theme.of(context).colorScheme.onSurface,
+                      color: cs.onSurface,
                       letterSpacing: -0.5,
                     ),
                   ),
-                  SizedBox(height: 1.h),
-                  Text(
-                    tripType == 'pickup'
-                        ? 'Morning Pickup'
-                        : 'Afternoon Dropoff',
-                    style: TextStyle(
-                      fontSize: 15,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w500,
+                  const SizedBox(height: 6),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 14, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: cs.primary.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(100),
+                    ),
+                    child: Text(
+                      isPickup ? 'Pickup Trip' : 'Dropoff Trip',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                        color: cs.primary,
+                      ),
                     ),
                   ),
-                ],
-              ),
-            ),
 
-            // Stats cards
-            Expanded(
-              flex: 3,
-              child: Column(
-                children: [
-                  // Completion rate card
+                  SizedBox(height: 4.h),
+
+                  // ── Attendance rate card ──────────────────────────────────
                   Container(
                     width: double.infinity,
-                    padding: EdgeInsets.all(5.w),
+                    padding: EdgeInsets.symmetric(
+                        vertical: 3.h, horizontal: 5.w),
                     decoration: BoxDecoration(
-                      color: Colors.white,
+                      color: _busminderTheme.cardColor,
                       borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                          color: cs.outline.withValues(alpha: 0.15)),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withOpacity(0.04),
+                          color: Colors.black.withValues(alpha: 0.04),
                           blurRadius: 16,
-                          offset: Offset(0, 4),
+                          offset: const Offset(0, 4),
                         ),
                       ],
                     ),
@@ -210,32 +217,46 @@ class _BusMinderTripHistoryScreenState
                             Text(
                               '$completionRate',
                               style: TextStyle(
-                                fontSize: 48,
+                                fontSize: 56,
                                 fontWeight: FontWeight.w800,
-                                color: Theme.of(context).colorScheme.secondary,
+                                color: cs.primary,
                                 height: 1,
                               ),
                             ),
                             Padding(
-                              padding: EdgeInsets.only(bottom: 0.8.h),
+                              padding:
+                                  EdgeInsets.only(bottom: 0.6.h, left: 2),
                               child: Text(
                                 '%',
                                 style: TextStyle(
-                                  fontSize: 24,
+                                  fontSize: 26,
                                   fontWeight: FontWeight.w700,
-                                  color: Theme.of(context).colorScheme.secondary,
+                                  color: cs.primary,
                                 ),
                               ),
                             ),
                           ],
                         ),
-                        SizedBox(height: 0.5.h),
+                        const SizedBox(height: 6),
                         Text(
                           'Attendance Rate',
                           style: TextStyle(
                             fontSize: 14,
-                            color: Theme.of(context).colorScheme.onSurfaceVariant,
+                            color: cs.onSurfaceVariant,
                             fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        // Progress bar
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: completionRate / 100,
+                            minHeight: 7,
+                            backgroundColor:
+                                cs.outline.withValues(alpha: 0.15),
+                            valueColor:
+                                AlwaysStoppedAnimation<Color>(cs.primary),
                           ),
                         ),
                       ],
@@ -244,104 +265,111 @@ class _BusMinderTripHistoryScreenState
 
                   SizedBox(height: 2.h),
 
-                  // Stats row
-                  Row(
-                    children: [
-                      Expanded(
-                          child: _buildStatCard('$totalStudents', 'Total',
-                              Icons.people_outline, Theme.of(context).colorScheme.primary)),
-                      SizedBox(width: 3.w),
-                      Expanded(
-                          child: _buildStatCard(
-                              '$studentsCompleted',
-                              'Done',
-                              Icons.check_circle_outline,
-                              Theme.of(context).colorScheme.secondary)),
-                      SizedBox(width: 3.w),
-                      Expanded(
-                          child: _buildStatCard('$studentsAbsent', 'Absent',
-                              Icons.cancel_outlined, Theme.of(context).colorScheme.error)),
-                    ],
+                  // ── Stats row ─────────────────────────────────────────────
+                  Container(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    decoration: BoxDecoration(
+                      color: _busminderTheme.cardColor,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                          color: cs.outline.withValues(alpha: 0.15)),
+                    ),
+                    child: Row(
+                      children: [
+                        _buildStatItem(cs, '$totalStudents', 'Total',
+                            cs.primary),
+                        _buildStatDivider(cs),
+                        _buildStatItem(cs, '$studentsCompleted', 'Done',
+                            const Color(0xFF2E7D32)),
+                        _buildStatDivider(cs),
+                        _buildStatItem(cs, '$studentsAbsent', 'Absent',
+                            cs.error),
+                      ],
+                    ),
                   ),
+
+                  SizedBox(height: 4.h),
                 ],
               ),
             ),
+          ),
 
-            // Done button
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.pushNamedAndRemoveUntil(
-                    context,
-                    '/busminder-start-shift-screen',
-                    (route) => false,
-                  );
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Colors.white,
-                  padding: EdgeInsets.symmetric(vertical: 2.h),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(14),
+          // ── Done button (pinned at bottom) ────────────────────────────────
+          Padding(
+            padding: EdgeInsets.fromLTRB(5.w, 0, 5.w, 3.h),
+            child: GestureDetector(
+              onTap: () => Navigator.pushNamedAndRemoveUntil(
+                context,
+                '/busminder-start-shift-screen',
+                (route) => false,
+              ),
+              child: Container(
+                height: 56,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      cs.primary,
+                      cs.primary.withValues(alpha: 0.85),
+                    ],
+                    begin: Alignment.centerLeft,
+                    end: Alignment.centerRight,
                   ),
-                  elevation: 0,
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      color: cs.primary.withValues(alpha: 0.35),
+                      blurRadius: 12,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
                 ),
-                child: Text(
-                  'Done',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700,
+                child: const Center(
+                  child: Text(
+                    'Done',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 17,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.3,
+                    ),
                   ),
                 ),
               ),
             ),
-            SizedBox(height: 3.h),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildStatCard(
-      String value, String label, IconData icon, Color color) {
-    return Container(
-      padding: EdgeInsets.symmetric(vertical: 2.h, horizontal: 3.w),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.04),
-            blurRadius: 12,
-            offset: Offset(0, 3),
-          ),
-        ],
-      ),
+  Widget _buildStatItem(
+      ColorScheme cs, String value, String label, Color color) {
+    return Expanded(
       child: Column(
         children: [
-          Icon(icon, color: color, size: 24),
-          SizedBox(height: 1.h),
           Text(
             value,
             style: TextStyle(
-              fontSize: 22,
-              fontWeight: FontWeight.w800,
-              color: Theme.of(context).colorScheme.onSurface,
-            ),
+                fontSize: 24, fontWeight: FontWeight.w800, color: color),
           ),
+          const SizedBox(height: 2),
           Text(
             label,
             style: TextStyle(
-              fontSize: 12,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w500,
-            ),
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: cs.onSurfaceVariant),
           ),
         ],
       ),
     );
   }
+
+  Widget _buildStatDivider(ColorScheme cs) => Container(
+        width: 1,
+        height: 36,
+        color: cs.outline.withValues(alpha: 0.2),
+      );
 
   Widget _buildFilterButton(String label, String filter, IconData icon) {
     final isSelected = _selectedFilter == filter;

--- a/DriversandMinders/lib/services/api_service.dart
+++ b/DriversandMinders/lib/services/api_service.dart
@@ -509,6 +509,34 @@ class ApiService {
     }
   }
 
+  // ==================== BusMinder Trip Management ====================
+
+  // Start a new trip as busminder
+  Future<Map<String, dynamic>> startBusminderTrip({String tripType = 'pickup'}) async {
+    try {
+      final response = await _dio.post(
+        '/api/busminders/start-trip/',
+        data: {'trip_type': tripType},
+      );
+      return response.data;
+    } on DioException catch (e) {
+      throw Exception(_extractErrorMessage(e, 'Failed to start trip'));
+    }
+  }
+
+  // Get active trip for current busminder
+  Future<Map<String, dynamic>?> getBusminderActiveTrip() async {
+    try {
+      final response = await _dio.get('/api/busminders/active-trip/');
+      if (response.data['trip'] != null) {
+        return response.data['trip'];
+      }
+      return null;
+    } catch (e) {
+      return null;
+    }
+  }
+
   // ==================== Location Tracking ====================
 
   // Push location update for trip

--- a/DriversandMinders/lib/widgets/busminder_drawer_widget.dart
+++ b/DriversandMinders/lib/widgets/busminder_drawer_widget.dart
@@ -34,106 +34,118 @@ class BusminderDrawerWidget extends StatelessWidget {
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
-      builder: (context) => Container(
-        padding: EdgeInsets.all(6.w),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: Colors.grey.shade300,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-            SizedBox(height: 3.h),
-            Container(
-              padding: EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: AppTheme.criticalAlert.withOpacity(0.1),
-                shape: BoxShape.circle,
-              ),
-              child: Icon(Icons.logout_rounded,
-                  size: 32, color: AppTheme.criticalAlert),
-            ),
-            SizedBox(height: 2.h),
-            Text(
-              'Logout?',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.w700,
-                color: AppTheme.textPrimary,
-              ),
-            ),
-            SizedBox(height: 1.h),
-            Text(
-              'You will need to login again to access your account',
-              textAlign: TextAlign.center,
-              style: TextStyle(color: AppTheme.textSecondary, fontSize: 14),
-            ),
-            SizedBox(height: 3.h),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: () => Navigator.pop(context),
-                    style: OutlinedButton.styleFrom(
-                      padding: EdgeInsets.symmetric(vertical: 14),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      side: BorderSide(color: Colors.grey.shade300),
-                    ),
-                    child: Text('Cancel',
-                        style: TextStyle(
-                            color: AppTheme.textPrimary,
-                            fontWeight: FontWeight.w600)),
-                  ),
+      builder: (context) {
+        final cs = Theme.of(context).colorScheme;
+        return Container(
+          padding: EdgeInsets.all(6.w),
+          decoration: BoxDecoration(
+            color: Theme.of(context).cardColor,
+            borderRadius:
+                const BorderRadius.vertical(top: Radius.circular(24)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: cs.outline.withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(2),
                 ),
-                SizedBox(width: 4.w),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () async {
-                      final apiService = ApiService();
-                      await apiService.clearToken();
-                      Navigator.pop(context);
-                      Navigator.pushNamedAndRemoveUntil(
-                        context,
-                        '/shared-login-screen',
-                        (route) => false,
-                      );
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppTheme.criticalAlert,
-                      padding: EdgeInsets.symmetric(vertical: 14),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      elevation: 0,
-                    ),
-                    child: Text('Logout',
-                        style: TextStyle(
-                            color: Colors.white, fontWeight: FontWeight.w600)),
-                  ),
+              ),
+              SizedBox(height: 3.h),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: cs.error.withValues(alpha: 0.1),
+                  shape: BoxShape.circle,
                 ),
-              ],
-            ),
-            SizedBox(height: 2.h),
-          ],
-        ),
-      ),
+                child:
+                    Icon(Icons.logout_rounded, size: 32, color: cs.error),
+              ),
+              SizedBox(height: 2.h),
+              Text(
+                'Logout?',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: cs.onSurface,
+                ),
+              ),
+              SizedBox(height: 1.h),
+              Text(
+                'You will need to login again to access your account',
+                textAlign: TextAlign.center,
+                style:
+                    TextStyle(color: cs.onSurfaceVariant, fontSize: 14),
+              ),
+              SizedBox(height: 3.h),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => Navigator.pop(context),
+                      style: OutlinedButton.styleFrom(
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        side: BorderSide(
+                            color: cs.outline.withValues(alpha: 0.5)),
+                      ),
+                      child: Text('Cancel',
+                          style: TextStyle(
+                              color: cs.onSurface,
+                              fontWeight: FontWeight.w600)),
+                    ),
+                  ),
+                  SizedBox(width: 4.w),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () async {
+                        final apiService = ApiService();
+                        await apiService.clearToken();
+                        Navigator.pop(context);
+                        Navigator.pushNamedAndRemoveUntil(
+                          context,
+                          '/shared-login-screen',
+                          (route) => false,
+                        );
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: cs.error,
+                        padding:
+                            const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        elevation: 0,
+                      ),
+                      child: const Text('Logout',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600)),
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: 2.h),
+            ],
+          ),
+        );
+      },
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    // Context here is inside Theme(busminderTheme) via the Scaffold,
+    // so Theme.of(context) returns the correct busminder theme.
+    final cs = Theme.of(context).colorScheme;
     return Drawer(
-      backgroundColor: Color(0xFFFAFAFC),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       child: SafeArea(
         child: Column(
           children: [
@@ -154,26 +166,23 @@ class BusminderDrawerWidget extends StatelessWidget {
                         height: 56,
                         decoration: BoxDecoration(
                           gradient: LinearGradient(
-                            colors: [
-                              AppTheme.primaryBusminder,
-                              AppTheme.primaryBusminderLight
-                            ],
+                            colors: [cs.primary, cs.primaryContainer],
                             begin: Alignment.topLeft,
                             end: Alignment.bottomRight,
                           ),
                           borderRadius: BorderRadius.circular(16),
                           boxShadow: [
                             BoxShadow(
-                              color: AppTheme.primaryBusminder.withOpacity(0.3),
+                              color: cs.primary.withValues(alpha: 0.3),
                               blurRadius: 12,
-                              offset: Offset(0, 4),
+                              offset: const Offset(0, 4),
                             ),
                           ],
                         ),
                         child: Center(
                           child: Text(
                             _getInitials(name),
-                            style: TextStyle(
+                            style: const TextStyle(
                               color: Colors.white,
                               fontWeight: FontWeight.w700,
                               fontSize: 18,
@@ -191,18 +200,17 @@ class BusminderDrawerWidget extends StatelessWidget {
                               style: TextStyle(
                                 fontSize: 18,
                                 fontWeight: FontWeight.w700,
-                                color: AppTheme.textPrimary,
+                                color: cs.onSurface,
                               ),
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            SizedBox(height: 4),
+                            const SizedBox(height: 4),
                             Container(
-                              padding: EdgeInsets.symmetric(
+                              padding: const EdgeInsets.symmetric(
                                   horizontal: 8, vertical: 3),
                               decoration: BoxDecoration(
-                                color:
-                                    AppTheme.primaryBusminder.withOpacity(0.1),
+                                color: cs.primary.withValues(alpha: 0.1),
                                 borderRadius: BorderRadius.circular(6),
                               ),
                               child: Text(
@@ -210,7 +218,7 @@ class BusminderDrawerWidget extends StatelessWidget {
                                 style: TextStyle(
                                   fontSize: 11,
                                   fontWeight: FontWeight.w600,
-                                  color: AppTheme.primaryBusminder,
+                                  color: cs.primary,
                                 ),
                               ),
                             ),
@@ -220,13 +228,13 @@ class BusminderDrawerWidget extends StatelessWidget {
                       GestureDetector(
                         onTap: () => Navigator.pop(context),
                         child: Container(
-                          padding: EdgeInsets.all(8),
+                          padding: const EdgeInsets.all(8),
                           decoration: BoxDecoration(
-                            color: Colors.grey.shade100,
+                            color: cs.onSurface.withValues(alpha: 0.06),
                             borderRadius: BorderRadius.circular(10),
                           ),
                           child: Icon(Icons.close,
-                              size: 20, color: AppTheme.textSecondary),
+                              size: 20, color: cs.onSurfaceVariant),
                         ),
                       ),
                     ],
@@ -238,7 +246,8 @@ class BusminderDrawerWidget extends StatelessWidget {
             // Divider
             Padding(
               padding: EdgeInsets.symmetric(horizontal: 5.w),
-              child: Divider(height: 1, color: Colors.grey.shade200),
+              child: Divider(
+                  height: 1, color: cs.outline.withValues(alpha: 0.4)),
             ),
 
             SizedBox(height: 2.h),
@@ -291,25 +300,25 @@ class BusminderDrawerWidget extends StatelessWidget {
                   _showLogoutConfirmation(context);
                 },
                 child: Container(
-                  padding: EdgeInsets.symmetric(vertical: 14),
+                  padding: const EdgeInsets.symmetric(vertical: 14),
                   decoration: BoxDecoration(
-                    color: AppTheme.criticalAlert.withOpacity(0.08),
+                    color: cs.error.withValues(alpha: 0.08),
                     borderRadius: BorderRadius.circular(12),
-                    border: Border.all(
-                        color: AppTheme.criticalAlert.withOpacity(0.2)),
+                    border:
+                        Border.all(color: cs.error.withValues(alpha: 0.2)),
                   ),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Icon(Icons.logout_rounded,
-                          size: 20, color: AppTheme.criticalAlert),
-                      SizedBox(width: 10),
+                          size: 20, color: cs.error),
+                      const SizedBox(width: 10),
                       Text(
                         'Logout',
                         style: TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w600,
-                          color: AppTheme.criticalAlert,
+                          color: cs.error,
                         ),
                       ),
                     ],
@@ -324,18 +333,21 @@ class BusminderDrawerWidget extends StatelessWidget {
   }
 
   Widget _buildSectionLabel(String label) {
-    return Padding(
-      padding: EdgeInsets.only(left: 4, top: 8, bottom: 12),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontSize: 11,
-          fontWeight: FontWeight.w700,
-          color: AppTheme.textSecondary.withOpacity(0.6),
-          letterSpacing: 1.2,
+    return Builder(builder: (context) {
+      final cs = Theme.of(context).colorScheme;
+      return Padding(
+        padding: const EdgeInsets.only(left: 4, top: 8, bottom: 12),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            color: cs.onSurfaceVariant.withValues(alpha: 0.6),
+            letterSpacing: 1.2,
+          ),
         ),
-      ),
-    );
+      );
+    });
   }
 
   Widget _buildMenuItem(
@@ -361,8 +373,8 @@ class BusminderDrawerWidget extends StatelessWidget {
             if (busId == null || tripType == null) {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
-                  content: Text('Please start a shift first'),
-                  backgroundColor: AppTheme.criticalAlert,
+                  content: const Text('Please start a shift first'),
+                  backgroundColor: Theme.of(context).colorScheme.error,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10)),
                 ),
@@ -380,7 +392,9 @@ class BusminderDrawerWidget extends StatelessWidget {
         margin: EdgeInsets.only(bottom: 6),
         padding: EdgeInsets.symmetric(horizontal: 14, vertical: 12),
         decoration: BoxDecoration(
-          color: isActive ? AppTheme.primaryBusminder : Colors.transparent,
+          color: isActive
+              ? Theme.of(context).colorScheme.primary
+              : Colors.transparent,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Row(
@@ -388,16 +402,20 @@ class BusminderDrawerWidget extends StatelessWidget {
             Icon(
               icon,
               size: 22,
-              color: isActive ? Colors.white : AppTheme.textSecondary,
+              color: isActive
+                  ? Colors.white
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
             ),
-            SizedBox(width: 14),
+            const SizedBox(width: 14),
             Expanded(
               child: Text(
                 title,
                 style: TextStyle(
                   fontSize: 15,
                   fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
-                  color: isActive ? Colors.white : AppTheme.textPrimary,
+                  color: isActive
+                      ? Colors.white
+                      : Theme.of(context).colorScheme.onSurface,
                 ),
               ),
             ),

--- a/DriversandMinders/lib/widgets/busminder_drawer_widget.dart
+++ b/DriversandMinders/lib/widgets/busminder_drawer_widget.dart
@@ -277,12 +277,6 @@ class BusminderDrawerWidget extends StatelessWidget {
                     title: 'Settings',
                     route: '/busminder-settings',
                   ),
-                  _buildMenuItem(
-                    context,
-                    icon: Icons.chat_bubble_outline_rounded,
-                    title: 'Communications',
-                    route: '/busminder-communications',
-                  ),
                 ],
               ),
             ),

--- a/server/busminders/urls.py
+++ b/server/busminders/urls.py
@@ -6,6 +6,8 @@ from .views import (
     MyBusesView,
     BusChildrenView,
     MarkAttendanceView,
+    start_trip_busminder,
+    get_active_trip_busminder,
     busminder_phone_login,
     check_busminder_email,
     busminder_magic_link_auth,
@@ -26,4 +28,6 @@ urlpatterns = [
     path("my-buses/", MyBusesView.as_view(), name="my-buses"),
     path("buses/<int:bus_id>/children/", BusChildrenView.as_view(), name="bus-children"),
     path("mark-attendance/", MarkAttendanceView.as_view(), name="mark-attendance"),
+    path("start-trip/", start_trip_busminder, name="busminder-start-trip"),
+    path("active-trip/", get_active_trip_busminder, name="busminder-active-trip"),
 ]

--- a/server/busminders/views.py
+++ b/server/busminders/views.py
@@ -393,6 +393,150 @@ class MarkAttendanceView(APIView):
 
 
 @api_view(['POST'])
+@permission_classes([IsAuthenticated, IsBusMinder])
+def start_trip_busminder(request):
+    """
+    Start a new trip initiated by a bus minder.
+
+    POST /api/busminders/start-trip/
+    Body: {"trip_type": "pickup" or "dropoff"}
+
+    Uses the driver assigned to the same bus as the busminder.
+    Returns the created Trip object.
+    """
+    from trips.models import Trip
+    from trips.serializers import TripSerializer
+    from assignments.models import Assignment, BusRoute
+    from django.utils import timezone
+
+    try:
+        busminder = BusMinder.objects.get(user=request.user)
+    except BusMinder.DoesNotExist:
+        return Response({"error": "Bus minder profile not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    # Find the bus assigned to this busminder
+    minder_assignment = Assignment.get_active_assignments_for(busminder, 'minder_to_bus').first()
+    if not minder_assignment:
+        return Response({"error": "You are not assigned to any bus"}, status=status.HTTP_400_BAD_REQUEST)
+
+    bus = minder_assignment.assigned_to
+
+    # Check for an already in-progress trip on this bus
+    existing_trip = Trip.objects.filter(
+        bus=bus,
+        bus_minder=request.user,
+        status='in-progress'
+    ).first()
+    if existing_trip:
+        return Response({
+            "message": "Trip already in progress",
+            "trip": TripSerializer(existing_trip).data
+        })
+
+    trip_type = request.data.get('trip_type', 'pickup')
+
+    # Find the driver assigned to this bus
+    driver_assignment = Assignment.get_assignments_to(bus, 'driver_to_bus').first()
+    if not driver_assignment:
+        return Response({
+            "error": "No driver assigned to this bus",
+            "message": "This bus has no driver assigned. Please contact the administrator."
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    driver_user = driver_assignment.assignee.user
+
+    # Find the route for this bus
+    route_assignment = Assignment.get_active_assignments_for(bus, 'bus_to_route').first()
+    route_name = None
+    if route_assignment:
+        route_obj = route_assignment.assigned_to
+        route_name = getattr(route_obj, 'name', None)
+    if not route_name:
+        route_obj = BusRoute.objects.filter(default_bus=bus, is_active=True).first()
+        if route_obj:
+            route_name = route_obj.name
+    if not route_name:
+        return Response({
+            "error": "No route assigned",
+            "message": "This bus has no route assigned. Please contact the administrator."
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    # Validate children are assigned to the bus
+    child_assignments = Assignment.get_assignments_to(bus, 'child_to_bus')
+    if not child_assignments.exists():
+        return Response({
+            "error": "No children assigned",
+            "message": "This bus has no children assigned. Please contact the administrator."
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    now = timezone.now()
+    trip = Trip.objects.create(
+        bus=bus,
+        driver=driver_user,
+        bus_minder=request.user,
+        trip_type=trip_type,
+        status='in-progress',
+        scheduled_time=now,
+        start_time=now,
+        route=route_name,
+    )
+
+    for child_assignment in child_assignments:
+        trip.children.add(child_assignment.assignee)
+
+    # Notify parents via WebSocket
+    try:
+        from channels.layers import get_channel_layer
+        from asgiref.sync import async_to_sync
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.group_send)(
+            f"bus_{bus.id}",
+            {
+                "type": "bus.trip_event",
+                "event_type": "trip_started",
+                "trip_id": trip.id,
+                "trip_type": trip.trip_type,
+                "scheduled_time": trip.scheduled_time.isoformat() if trip.scheduled_time else None,
+                "bus_latitude": float(bus.latitude) if bus.latitude else None,
+                "bus_longitude": float(bus.longitude) if bus.longitude else None,
+                "bus_speed": float(bus.speed) if bus.speed else 0.0,
+                "bus_heading": float(bus.heading) if bus.heading else 0.0,
+            }
+        )
+    except Exception:
+        pass
+
+    return Response({
+        "message": "Trip started successfully",
+        "trip": TripSerializer(trip).data
+    }, status=status.HTTP_201_CREATED)
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated, IsBusMinder])
+def get_active_trip_busminder(request):
+    """
+    Get the current active trip for this bus minder.
+
+    GET /api/busminders/active-trip/
+
+    Returns: Trip object or null if no active trip.
+    """
+    from trips.models import Trip
+    from trips.serializers import TripSerializer
+
+    active_trip = Trip.objects.filter(
+        bus_minder=request.user,
+        status='in-progress'
+    ).first()
+
+    if active_trip:
+        return Response({"trip": TripSerializer(active_trip).data})
+    else:
+        return Response({"trip": None, "message": "No active trip"})
+
+
+@api_view(['POST'])
 @permission_classes([AllowAny])
 def busminder_phone_login(request):
     """


### PR DESCRIPTION
Log in as a BusMinder and start a Pickup trip — confirm `/api/busminders/start-trip/` returns 201 and `trip_id` is saved
      - Navigate away and return — confirm "Continue Trip" appears (trip persists via `/api/busminders/active-trip/`)
      - Active trip screen shows correct bus, route, driver name, start time, live clock, elapsed timer
      - Mark students as picked up / absent — confirm pills update and attendance is saved
      - End shift — confirm completion screen shows busminder green Done button and correct stats
      - Toggle dark mode in Settings — confirm all busminder screens (home, active trip, profile, settings, drawer, completion) switch correctly with no invisible text
      - Verify driver screens are unaffected by busminder dark mode toggle
      - Verify Parents app notifications still fire on trip start/end
