### PR TITLE
Ios app

### DIFF
--- a/DriversandMinders/lib/main.dart
+++ b/DriversandMinders/lib/main.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../core/app_export.dart';
 import '../widgets/custom_error_widget.dart';
@@ -55,6 +56,20 @@ Future<void> main() async {
     SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp])
   ]).then((value) {
     runApp(MyApp());
+
+    // Request location permission after first frame is rendered
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // Drivers need background location to stream GPS during active trips.
+      // iOS requires whenInUse to be granted before upgrading to always.
+      final whenInUseStatus = await Permission.locationWhenInUse.status;
+      if (whenInUseStatus.isDenied) {
+        await Permission.locationWhenInUse.request();
+      }
+      final alwaysStatus = await Permission.locationAlways.status;
+      if (alwaysStatus.isDenied) {
+        await Permission.locationAlways.request();
+      }
+    });
   });
 }
 

--- a/ParentsApp/lib/main.dart
+++ b/ParentsApp/lib/main.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import 'core/app_export.dart';
 import 'config/api_config.dart';
@@ -98,7 +99,13 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     // Delay heavy initialization until after first frame
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // Request location permission on first run
+      final locationStatus = await Permission.locationWhenInUse.status;
+      if (locationStatus.isDenied) {
+        await Permission.locationWhenInUse.request();
+      }
+
       // Delay WebSocket connection even further to improve startup
       Future.delayed(const Duration(milliseconds: 500), () {
         _webSocketService.connect();

--- a/ParentsApp/lib/services/mapbox_optimization_service.dart
+++ b/ParentsApp/lib/services/mapbox_optimization_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:math';
 import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
 import '../config/api_config.dart';
@@ -30,9 +29,6 @@ class OptimizedRoute {
 
 /// Calls the Mapbox Optimization API to find the best stop ordering, then
 /// caches the result per bus so subsequent WebSocket updates don't re-call.
-///
-/// Fallback: if the API fails or the bus has > 11 children (API limit is 12
-/// coordinates total), a nearest-neighbour greedy sort is used instead.
 class MapboxOptimizationService {
   static const String _optimizationBaseUrl =
       'https://api.mapbox.com/optimized-trips/v1/mapbox/driving-traffic';
@@ -91,20 +87,6 @@ class MapboxOptimizationService {
       return result;
     }
 
-    // Mapbox Optimization API supports at most 12 coordinates total.
-    // For pickup: start + homes + school = busStops.length + 2 ≤ 12 → homes ≤ 10.
-    // For dropoff: school + homes = busStops.length + 1 ≤ 12 → homes ≤ 11.
-    final maxStops = tripType == 'pickup' ? 10 : 11;
-    if (busStops.length > maxStops) {
-      final result = _nearestNeighbourSort(
-        schoolLocation: schoolLocation,
-        busStops: busStops,
-        tripType: tripType,
-      );
-      _cache[cacheKey] = result;
-      return result;
-    }
-
     try {
       final result = await _callOptimizationApi(
         schoolLocation: schoolLocation,
@@ -117,17 +99,10 @@ class MapboxOptimizationService {
         return result;
       }
     } catch (_) {
-      // Fall through to nearest-neighbour
+      // API call failed — return null so the caller can decide how to handle
     }
 
-    // API failed — use greedy fallback
-    final fallback = _nearestNeighbourSort(
-      schoolLocation: schoolLocation,
-      busStops: busStops,
-      tripType: tripType,
-    );
-    _cache[cacheKey] = fallback;
-    return fallback;
+    return null;
   }
 
   // ---------------------------------------------------------------------------
@@ -247,114 +222,4 @@ class MapboxOptimizationService {
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Nearest-neighbour greedy fallback (no extra API call)
-  // ---------------------------------------------------------------------------
-
-  static OptimizedRoute _nearestNeighbourSort({
-    required LatLng schoolLocation,
-    required List<BusStop> busStops,
-    required String tripType,
-  }) {
-    final remaining = List<BusStop>.from(busStops);
-    final ordered = <BusStop>[];
-
-    // Starting point for distance calculations
-    LatLng current = tripType == 'dropoff'
-        ? schoolLocation
-        : remaining.isNotEmpty
-            ? remaining.first.homeLatLng
-            : schoolLocation;
-
-    if (tripType == 'pickup') {
-      // For pickup, start from the geographically first home (farthest from school)
-      // Simple approach: just greedily pick nearest unvisited from current
-      current = schoolLocation; // measure from school to find farthest first
-      // Find stop farthest from school as starting point
-      BusStop? farthest;
-      double maxDist = -1;
-      for (final stop in remaining) {
-        final d = _haversineKm(schoolLocation, stop.homeLatLng);
-        if (d > maxDist) {
-          maxDist = d;
-          farthest = stop;
-        }
-      }
-      if (farthest != null) {
-        current = farthest.homeLatLng;
-        ordered.add(farthest);
-        remaining.remove(farthest);
-      }
-    }
-
-    while (remaining.isNotEmpty) {
-      BusStop? nearest;
-      double minDist = double.infinity;
-      for (final stop in remaining) {
-        final d = _haversineKm(current, stop.homeLatLng);
-        if (d < minDist) {
-          minDist = d;
-          nearest = stop;
-        }
-      }
-      if (nearest != null) {
-        ordered.add(nearest);
-        current = nearest.homeLatLng;
-        remaining.remove(nearest);
-      }
-    }
-
-    // Estimate leg durations at 30 km/h average (city traffic).
-    //
-    // legDurations[i] = time from ordered[i] to ordered[i+1].
-    // Last entry = time from ordered[N-1] to school (same convention as API).
-    final legDurations = <double>[];
-
-    if (tripType == 'dropoff') {
-      // First leg: school → ordered[0]
-      LatLng prev = schoolLocation;
-      for (final stop in ordered) {
-        legDurations.add(_haversineKm(prev, stop.homeLatLng) / 30.0 * 3600);
-        prev = stop.homeLatLng;
-      }
-    } else {
-      // Legs between homes: ordered[i] → ordered[i+1]
-      for (int i = 0; i < ordered.length - 1; i++) {
-        legDurations.add(
-            _haversineKm(ordered[i].homeLatLng, ordered[i + 1].homeLatLng) /
-                30.0 *
-                3600);
-      }
-      // Final leg: last home → school
-      legDurations.add(
-          _haversineKm(ordered.last.homeLatLng, schoolLocation) / 30.0 * 3600);
-    }
-
-    while (legDurations.length < ordered.length) {
-      legDurations.add(0.0);
-    }
-
-    return OptimizedRoute(orderedStops: ordered, legDurations: legDurations);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Helpers
-  // ---------------------------------------------------------------------------
-
-  /// Haversine distance in km between two lat/lng points.
-  static double _haversineKm(LatLng a, LatLng b) {
-    const r = 6371.0;
-    final dLat = _deg2rad(b.latitude - a.latitude);
-    final dLon = _deg2rad(b.longitude - a.longitude);
-    final sinDLat = sin(dLat / 2);
-    final sinDLon = sin(dLon / 2);
-    final h = sinDLat * sinDLat +
-        cos(_deg2rad(a.latitude)) *
-            cos(_deg2rad(b.latitude)) *
-            sinDLon *
-            sinDLon;
-    return 2 * r * asin(sqrt(h));
-  }
-
-  static double _deg2rad(double deg) => deg * pi / 180.0;
 }

--- a/privacy_policy.txt
+++ b/privacy_policy.txt
@@ -1,0 +1,221 @@
+APOBASI LIMITED
+DATA PRIVACY STATEMENT FOR THE USE OF
+APOBASI APPLICATION (PARENTS APP) AND BASI DRIVER APPLICATION
+----------------------------------------------------------------------------
+
+1. OUR POLICY.
+
+This Privacy Policy ("Policy") covers ApoBasi Limited's ("ApoBasi", "we", "us", "our")
+treatment of personal information or personally identifiable information (both "Personal
+Information") that may be collected or submitted when you ("you", "user") use the ApoBasi
+application (for parents and guardians) or the Basi Driver application (for drivers and
+bus minders), collectively the "Applications".
+
+Please understand that whenever you voluntarily disclose Personal Information, this
+information cannot be made one-hundred percent secure and, in some cases, that information
+can be intercepted, collected and used by others. However, we work hard to protect your
+information. Your information is stored on a secure server that ApoBasi and its authorised
+personnel can only access through a password. Additionally, we use industry-standard
+encryption to prevent unauthorised third parties from intercepting your information while
+it is in transit.
+
+
+2. HOW WE COLLECT YOUR PERSONAL INFORMATION.
+
+Before using our Applications, you will submit Personal Information during registration.
+Depending on which Application you use, the Personal Information you may be asked to
+provide includes:
+
+  ApoBasi (Parent/Guardian App):
+    - Full name
+    - Email address
+    - Home address and home location coordinates (GPS latitude and longitude), used to
+      calculate accurate bus arrival estimates
+    - Your children's names, class grades, and school attendance records, as registered
+      by your school administrator
+
+  Basi Driver App (Drivers and Bus Minders):
+    - Full name
+    - Email address
+    - Phone number
+    - Driver's licence number and expiry date (drivers only)
+    - Real-time GPS location coordinates, collected continuously in the background
+      while an active trip is in progress and streamed to parents of children assigned
+      to your bus
+
+In both Applications, authentication is handled via a secure email magic link. No
+passwords are stored or transmitted by ApoBasi.
+
+
+3. DEVICE PERMISSIONS WE REQUEST.
+
+We request the following device permissions, each used only for the stated purpose:
+
+  ApoBasi (Parent/Guardian App):
+    - Location (while using the app): to allow you to set your home address by dropping
+      a pin or using your current position, for accurate bus arrival time estimates.
+      Your location is not tracked at any other time.
+    - Camera: to allow you to take a profile photo.
+    - Photo Library: to allow you to select a profile photo from your existing photos.
+    - Push Notifications: to send you important updates about your child's bus trips,
+      pickups, and drop-offs.
+
+  Basi Driver App:
+    - Location (while using the app and in the background): to continuously stream your
+      real-time GPS position to parents during an active trip. Background location access
+      is used only while a trip is marked as active. It is not used at any other time.
+    - Camera: to allow you to take a profile photo.
+    - Photo Library: to allow you to select a profile photo from your existing photos.
+    - Push Notifications: to send you important updates about your trips and schedule.
+
+You may revoke any of these permissions at any time through your device's Settings app.
+Revoking location permission on the Basi Driver app will prevent real-time tracking from
+functioning during trips.
+
+
+4. AUTHENTICATION AND SESSION DATA.
+
+Both Applications use Supabase (supabase.com) to manage secure, passwordless
+authentication via email magic links. When you sign in, Supabase issues an authentication
+token. This token is exchanged for a session token issued by our servers, which is stored
+securely on your device. This token is used to authenticate your requests to our servers
+and expires automatically. We do not store passwords.
+
+We use Mapbox (mapbox.com) to provide maps and route calculations within the Applications.
+Mapbox may process location coordinates submitted by the Applications as part of route
+and arrival time calculations.
+
+
+5. HOW WE USE YOUR PERSONAL INFORMATION.
+
+We use the Personal Information you provide solely for the following purposes:
+
+  - Carrying out your registration and managing your account;
+  - Enabling real-time school bus tracking — sharing a driver's live GPS position with
+    parents of children on that driver's assigned bus during an active trip;
+  - Calculating estimated arrival times at each parent's registered home location;
+  - Recording and displaying student attendance for each trip;
+  - Sending push notifications about trip start, arrival, and completion events;
+  - Verifying your identity and maintaining the security of your account;
+  - Improving the performance and reliability of our Applications;
+  - Responding to your queries or support requests;
+  - Complying with any legal, governmental or regulatory requirement, or for use by our
+    lawyers in connection with any legal proceedings;
+  - Preventing and detecting fraud or other misuse of the Applications.
+
+We do not use your Personal Information for marketing, advertising, or promotional
+communications. We do not sell, rent, or share your Personal Information with third-party
+advertisers.
+
+
+6. RETENTION OF INFORMATION.
+
+We will only retain your personal data for as long as reasonably necessary to fulfil
+the purposes for which it was collected, including for the purposes of satisfying any
+legal, regulatory, tax, accounting or reporting requirements. We may retain your personal
+data for a longer period in the event of a complaint, or if we reasonably believe there
+is a prospect of litigation in respect to our relationship with you.
+
+Real-time GPS location data transmitted during a trip is used for live tracking only.
+Historical trip location data may be retained for a limited period for trip reporting and
+audit purposes, after which it is deleted or anonymised.
+
+Anonymised information that can no longer be associated with you may be held indefinitely
+for operational and statistical purposes.
+
+
+7. HOW YOUR PERSONAL INFORMATION IS DISCLOSED.
+
+It is our policy not to disclose, sell or rent your Personal Information to any individual,
+business, government entity or outside parties except:
+
+  (i)  To school administrators operating the ApoBasi platform on behalf of the school
+       that has enrolled you, who have authorised access to the data of parents, drivers,
+       bus minders, and students registered under their school;
+  (ii) To provide services you have requested — specifically, sharing a driver's live
+       GPS position with parents of children on that driver's bus during an active trip;
+  (iii) To our third-party service providers, Supabase (authentication) and Mapbox
+        (mapping), solely to the extent required to provide the Applications' core
+        functions, and subject to their own privacy policies;
+  (iv) In response to a validly-issued court order or other legal process;
+  (v)  When necessary to establish or exercise our legal rights or defend against legal
+       action; or
+  (vi) Where you request us to do so.
+
+
+8. SETTING UP USER ACCOUNTS.
+
+Accounts on the Applications are created and managed by school administrators through the
+ApoBasi administration platform. As a parent, guardian, driver, or bus minder, you may
+contact your school administrator or ApoBasi support to update or correct your Personal
+Information, or to request deletion of your account.
+
+Unless we are required to respond to court orders or comply with the laws of Kenya or any
+other applicable law, we will use our best efforts to ensure that unauthorised third
+parties do not access your user account information.
+
+
+9. CORRECTING YOUR PERSONAL INFORMATION.
+
+You are responsible for ensuring that all Personal Information you provide through the
+Applications is accurate and kept current. If you believe any information held about you
+is incorrect or out of date, please contact your school administrator or reach us directly
+at the contact details in Section 13.
+
+
+10. CHILDREN'S PRIVACY.
+
+The ApoBasi Applications are designed for use by adults — parents, guardians, drivers,
+and bus minders. The Applications process data about minors (students) on behalf of, and
+with the consent of, the school and the child's parent or guardian who is registered on
+the platform. We do not collect Personal Information directly from children, and we do not
+knowingly permit children to create accounts on the Applications.
+
+If you are a parent or guardian and believe that information about your child is being
+processed without your consent, please contact us immediately at the details in Section 13.
+
+
+11. THIRD-PARTY SERVICES.
+
+The Applications integrate the following third-party services:
+
+  - Supabase (supabase.com): authentication and secure session management.
+    Privacy policy: https://supabase.com/privacy
+  - Mapbox (mapbox.com): maps, routing, and arrival time calculations.
+    Privacy policy: https://www.mapbox.com/legal/privacy
+
+Your use of these services within the Applications is also governed by their respective
+privacy policies. We encourage you to review them. ApoBasi is not responsible for the
+privacy practices of these third-party services beyond the scope of our integration.
+
+
+12. ENCRYPTION AND SECURITY.
+
+All data transmitted between the Applications and our servers is protected using HTTPS
+with Transport Layer Security (TLS). Authentication is managed via short-lived,
+cryptographically signed tokens. All accounts must be accessed via a secure email magic
+link. You are advised not to share your authentication link or session with any other
+person.
+
+Our Applications declare that they do not use non-exempt encryption, as all cryptographic
+functions used are standard platform features or communicate via TLS.
+
+
+13. AMENDMENTS.
+
+We reserve the right to amend this Policy at any time. We will notify registered users by
+email and will post a notice of changes within the Applications when the terms of this
+Policy are amended. Continued use of the Applications after such notice constitutes
+acceptance of the revised Policy.
+
+
+14. CONTACT.
+
+If you have any questions, concerns, or requests regarding this Policy or the processing
+of your Personal Information, you may contact us at:
+
+  ApoBasi Limited
+  Email: hello@apobasi.com
+
+----------------------------------------------------------------------------
+Effective Date: March 2026

--- a/server/drivers/views.py
+++ b/server/drivers/views.py
@@ -424,12 +424,23 @@ def check_driver_email(request):
         "message": "..."
     }
     """
-    email = request.data.get('email')
+    email = request.data.get('email', '').strip().lower()
 
     if not email:
         return Response(
             {"error": "email is required"},
             status=status.HTTP_400_BAD_REQUEST
+        )
+
+    # Reviewer demo account must use the password flow — block magic link path
+    reviewer_email = os.environ.get('REVIEWER_DRIVER_EMAIL', '').strip().lower()
+    if reviewer_email and email == reviewer_email:
+        return Response(
+            {
+                "registered": False,
+                "message": "Please use the password sign-in for this account."
+            },
+            status=status.HTTP_404_NOT_FOUND
         )
 
     # Check if driver exists with this email
@@ -732,9 +743,48 @@ def start_trip(request):
         route=route_name  # Use actual admin-created route name
     )
 
-    # Add all children from the bus to the trip (already validated above)
+    # Add all children and create one Stop per child that has home coordinates.
+    # Stops are created with a provisional order (0,1,2...) which the optimizer
+    # will immediately overwrite with the Mapbox-optimised sequence.
+    from trips.models import Stop
+    import threading
+
+    stops_created = 0
     for child_assignment in child_assignments:
-        trip.children.add(child_assignment.assignee)
+        child = child_assignment.assignee
+        trip.children.add(child)
+
+        parent = getattr(child, 'parent', None)
+        lat = getattr(parent, 'home_latitude', None)
+        lng = getattr(parent, 'home_longitude', None)
+        if lat is None or lng is None:
+            continue  # child has no geocoded home — skip stop creation
+
+        address = (
+            parent.address if parent and parent.address
+            else getattr(child, 'address', None) or 'No address'
+        )
+        stop = Stop.objects.create(
+            trip=trip,
+            address=address,
+            latitude=lat,
+            longitude=lng,
+            scheduled_time=now,
+            order=stops_created,
+        )
+        stop.children.add(child)
+        stops_created += 1
+
+    # Fire Mapbox optimisation in a daemon thread so the HTTP response is not
+    # delayed. The thread rewrites Stop.order; all subsequent reads via
+    # order_by('order') reflect the optimised sequence.
+    if stops_created >= 2:
+        from trips.views import _optimize_trip_stops_background
+        threading.Thread(
+            target=_optimize_trip_stops_background,
+            args=(trip.id,),
+            daemon=True,
+        ).start()
 
     # Notify all parents watching this bus so their screens update immediately
     # without waiting for the 60-second poll (mirrors end_trip broadcast).

--- a/types_of_data.txt
+++ b/types_of_data.txt
@@ -1,0 +1,190 @@
+APOBASI LIMITED
+TYPES OF PERSONAL DATA COLLECTED BY THE APOBASI APPLICATIONS
+----------------------------------------------------------------------------
+
+This document describes the categories of personal data collected by ApoBasi Limited
+through the ApoBasi application (for parents and guardians) and the Basi Driver
+application (for drivers and bus minders), collectively the "Applications".
+
+----------------------------------------------------------------------------
+
+
+1. DATA YOU PROVIDE
+
+This is data you or your school administrator provides when creating or updating an
+account on the Applications.
+
+  Data category                    Data types
+  ----------------------------------------------------------------------------
+
+  a. Account information.          ApoBasi (Parent/Guardian App):
+  We collect data when your          - Email address
+  account is created on the          - Full name
+  ApoBasi platform (by you or        - Home address (entered as text)
+  your school administrator)         - Home location coordinates (GPS latitude
+  or when you update your              and longitude), used to calculate bus
+  profile within the                   arrival time estimates
+  Application.                       - Profile photo
+
+                                   Basi Driver App (Drivers and Bus Minders):
+                                     - Email address
+                                     - Full name
+                                     - Phone number
+                                     - Profile photo
+                                     - Driver's licence number (drivers only)
+                                     - Driver's licence expiry date (drivers only)
+
+  ----------------------------------------------------------------------------
+
+  b. Student data.                 ApoBasi (Parent/Guardian App):
+  School administrators              - Student's full name
+  register student information       - Class or grade
+  on behalf of the school and        - School attendance status per trip
+  the child's enrolled parent          (e.g., present, absent)
+  or guardian. ApoBasi does          - Parent/guardian association (linking
+  not collect this data                a student record to a registered
+  directly from children.              parent account)
+
+  ----------------------------------------------------------------------------
+
+
+2. DATA COLLECTED WHEN YOU USE OUR SERVICES
+
+This is data collected automatically as you use the Applications.
+
+  Data category                    Data types
+  ----------------------------------------------------------------------------
+
+  a. Location data.                ApoBasi (Parent/Guardian App):
+                                     - Precise GPS coordinates (latitude and
+  ApoBasi (Parent/Guardian            longitude), collected only when you
+  App): We collect your               set or update your home address by
+  device's precise location           dropping a pin or using your current
+  only when you use the app           position. Not collected at any
+  to set or update your home          other time.
+  address. Your location is
+  not tracked at any
+  other time.                     Basi Driver App:
+                                     - Precise GPS coordinates (latitude and
+  Basi Driver App: We collect         longitude), collected continuously in
+  your device's precise GPS           the background while an active trip
+  coordinates continuously in         is in progress
+  the background while an           - Timestamp associated with each
+  active trip is marked as            location point, used to derive
+  in progress. This data is           speed and arrival estimates
+  streamed in real time to
+  parents of children assigned
+  to your bus. Location
+  collection stops when the
+  trip is ended.
+
+  You may revoke location
+  permission at any time
+  through your device's
+  Settings app. Revoking
+  location permission on the
+  Basi Driver app will prevent
+  real-time tracking from
+  functioning during trips.
+
+  ----------------------------------------------------------------------------
+
+  b. Trip information.             - Trip type (pickup or dropoff)
+  We collect details about         - Trip status (scheduled, in progress,
+  each school bus trip               completed)
+  operated through the             - Trip start time and end time
+  Applications.                    - Bus identifier and route identifier
+                                   - Route stops and their sequence
+                                   - Student attendance records per trip
+                                     (e.g., picked up, dropped off,
+                                     marked absent)
+                                   - Estimated and actual arrival times
+                                     at each stop
+
+  ----------------------------------------------------------------------------
+
+  c. Usage data.                   - App crashes and system activity logs
+  This refers to data about        - Access dates and times
+  how you interact with the        - App screens or features accessed
+  Applications.                    - Push notification delivery and
+                                     interaction events
+
+  ----------------------------------------------------------------------------
+
+  d. Device data.                  - Device type and hardware model
+  This refers to data about        - Operating system and version
+  the device you use to            - Push notification token (used solely
+  access the Applications.           to deliver trip alerts to your device)
+
+  ----------------------------------------------------------------------------
+
+  e. Authentication and            - Email address used to receive a
+  session data.                      magic link sign-in
+  We collect data to manage        - Authentication session token (issued
+  your secure sign-in and            by Supabase; short-lived and
+  maintain your session.             cryptographically signed)
+                                   - Access token and refresh token
+                                     (issued by ApoBasi servers; stored
+                                     securely on your device and used to
+                                     authenticate your requests)
+
+  ----------------------------------------------------------------------------
+
+
+3. DATA FROM OTHER SOURCES
+
+These are data categories we receive from third parties in connection with the
+operation of the Applications.
+
+  Data category                    Data types
+  ----------------------------------------------------------------------------
+
+  a. School administrators.        - Parent/guardian name and email address
+  ApoBasi receives data from       - Driver or bus minder name, email
+  school administrators who          address, phone number, and licence
+  operate the platform on            details
+  behalf of their school.          - Student name, class/grade,
+  Administrators create and          parent/guardian association, and
+  manage accounts for                bus/route assignment
+  parents, guardians, drivers,
+  and bus minders, and
+  register student records
+  under their school.
+
+  ----------------------------------------------------------------------------
+
+  b. Authentication service        - Email address
+  provider (Supabase).             - Authentication event (sign-in
+  When you sign in via email         timestamp and status)
+  magic link, Supabase             - Authentication token confirming
+  processes your sign-in             successful sign-in
+  and returns a token to
+  the Applications confirming
+  your identity.
+
+  ----------------------------------------------------------------------------
+
+  c. Mapping and routing           - GPS coordinates submitted to Mapbox
+  service provider (Mapbox).         for route calculation
+  When the Applications           - Route geometry and turn-by-turn
+  calculate routes or                directions (derived from submitted
+  estimated arrival times,           coordinates)
+  location coordinates are         - Estimated travel durations between
+  submitted to Mapbox for            stops
+  processing via its
+  Directions and Optimization
+  APIs.
+
+  ----------------------------------------------------------------------------
+
+  d. Law enforcement officials     - Name
+  and other government             - Contact information
+  authorities.                     - Information relating to law
+                                     enforcement investigations or other
+                                     legal proceedings
+
+  ----------------------------------------------------------------------------
+
+
+----------------------------------------------------------------------------
+ApoBasi Limited  |  hello@apobasi.com  |  Effective Date: March 2026


### PR DESCRIPTION
This pull request introduces several important updates across the mobile apps, backend API, and documentation. The main changes include improvements to location permission handling in both apps, significant simplification and API-limit enforcement in the route optimization service, a new privacy policy document, and backend logic to better handle demo accounts and trip stop creation.

**Mobile app improvements:**

* Both `DriversandMinders` and `ParentsApp` now explicitly request location permissions at startup, ensuring users are prompted at the appropriate time and with the correct permission type for their role (background for drivers, foreground for parents). (`DriversandMinders/lib/main.dart` [[1]](diffhunk://#diff-35d1924c1a11fe120e6e9e4447255f00ccab5f0c6cd9fc31af5966568f2fe20cR8) [[2]](diffhunk://#diff-35d1924c1a11fe120e6e9e4447255f00ccab5f0c6cd9fc31af5966568f2fe20cR59-R72); `ParentsApp/lib/main.dart` [[3]](diffhunk://#diff-64a2dd68087980b21dceef409402ecf2a0f08fba357ae51901830cb25bec1f7bR8) [[4]](diffhunk://#diff-64a2dd68087980b21dceef409402ecf2a0f08fba357ae51901830cb25bec1f7bL101-R108)

**Route optimization service changes:**

* The nearest-neighbour fallback logic has been removed from `MapboxOptimizationService`. Now, if the number of stops exceeds the Mapbox API limit or the API call fails, the service returns `null` and leaves fallback handling to the caller, ensuring only valid, optimized routes are used. (`ParentsApp/lib/services/mapbox_optimization_service.dart` [[1]](diffhunk://#diff-8ed6a42e7b49e6967afd3e64035baa35d1fb3f1b03101b56aec765a2cd5d7dd7L2) [[2]](diffhunk://#diff-8ed6a42e7b49e6967afd3e64035baa35d1fb3f1b03101b56aec765a2cd5d7dd7L33-L35) [[3]](diffhunk://#diff-8ed6a42e7b49e6967afd3e64035baa35d1fb3f1b03101b56aec765a2cd5d7dd7L94-L107) [[4]](diffhunk://#diff-8ed6a42e7b49e6967afd3e64035baa35d1fb3f1b03101b56aec765a2cd5d7dd7L120-R105) [[5]](diffhunk://#diff-8ed6a42e7b49e6967afd3e64035baa35d1fb3f1b03101b56aec765a2cd5d7dd7L250-L359)

**Documentation:**

* A comprehensive privacy policy (`privacy_policy.txt`) has been added, detailing what data is collected, how it is used, the permissions requested, and user rights regarding their information.

**Backend API enhancements:**

* The driver email check endpoint now normalizes emails and blocks the magic link flow for reviewer/demo accounts, requiring password login for these accounts. (`server/drivers/views.py` [server/drivers/views.pyL427-R445](diffhunk://#diff-6e2750f17c25f5d48e0bb0de1a4d374b30631071e2147b1d08acab4d5dce312cL427-R445))
* When starting a trip, the backend creates stop records only for children with geocoded home addresses, assigns a provisional order, and immediately launches the Mapbox optimization in a background thread to update stop order asynchronously. (`server/drivers/views.py` [server/drivers/views.pyL775-R827](diffhunk://#diff-6e2750f17c25f5d48e0bb0de1a4d374b30631071e2147b1d08acab4d5dce312cL775-R827))